### PR TITLE
Change dictionary to SimpleNamespace

### DIFF
--- a/soft4pes/control/mpc/mpc_enum.py
+++ b/soft4pes/control/mpc/mpc_enum.py
@@ -1,5 +1,6 @@
 """ Enumeration based finite-control set model-predictive controller"""
 
+from types import SimpleNamespace
 import numpy as np
 from soft4pes.utils.conversions import dq_2_alpha_beta
 
@@ -18,8 +19,8 @@ class CurrCtrMpcEnum:
         Sampling time [s].
     i_ref_seq_dq : Sequence
         Current reference sequence instance in dq-frame [pu].
-    state_space : dict
-        Dictionary containing the discrete state-space model of the system.
+    state_space : SimpleNamespace
+        Discrete state-space model of the system.
     """
 
     def __init__(self, lambda_u, Np, Ts, i_ref_seq_dq):
@@ -42,7 +43,7 @@ class CurrCtrMpcEnum:
         self.Ts = Ts
         self.u_km1 = np.array([0, 0, 0])
         self.i_ref_seq_dq = i_ref_seq_dq
-        self.state_space = dict()
+        self.state_space = SimpleNamespace()
 
     def __call__(self, sys, conv, t):
         """
@@ -151,9 +152,9 @@ class CurrCtrMpcEnum:
                 x_kp1 = xk
             else:
                 # Compute the next state
-                x_kp1 = np.dot(self.state_space['A'], xk) + \
-                        np.dot(self.state_space['B1'], u_k) + \
-                        np.dot(self.state_space['B2'], vg)
+                x_kp1 = np.dot(self.state_space.A, xk) + \
+                        np.dot(self.state_space.B1, u_k) + \
+                        np.dot(self.state_space.B2, vg)
 
                 # Calculate the cost of reference tracking and control effort
                 i_error = np.sum((i_ref_kp1 - sys.get_current(x_kp1))**2)

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -1,5 +1,6 @@
 """ Model of a grid with stiff voltage source and RL-load in alpha-beta frame"""
 
+from types import SimpleNamespace
 import numpy as np
 from soft4pes.utils.conversions import abc_2_alpha_beta
 
@@ -61,8 +62,9 @@ class RLGrid:
 
         Returns
         -------
-        dict
-            A dictionary containing matrices A, B1, B2, and C of the state-space model.
+        SimpleNamespace
+            A SimpleNamespace object containing matrices A, B1, B2, and C of the 
+            state-space model. 
         """
         Rg = self.Rg
         Xg = self.Xg
@@ -81,7 +83,7 @@ class RLGrid:
         B2 = G2 * Ts
         C = np.array([[1, 0], [0, 1]])
 
-        return {'A': A, 'B1': B1, 'B2': B2, 'C': C}
+        return SimpleNamespace(A=A, B1=B1, B2=B2, C=C)
 
     def get_grid_voltage(self, t):
         """

--- a/soft4pes/sim/simulation.py
+++ b/soft4pes/sim/simulation.py
@@ -73,8 +73,8 @@ class Simulation:
                 self.conv.v_dc, self.ctr.Ts)
             vg = self.sys.get_grid_voltage(t)
 
-            x_kp1 = np.dot(matrices['A'], self.sys.x) + np.dot(
-                matrices['B1'], u) + np.dot(matrices['B2'], vg)
+            x_kp1 = np.dot(matrices.A, self.sys.x) + np.dot(
+                matrices.B1, u) + np.dot(matrices.B2, vg)
 
             self.sys.update_state(x_kp1)
 


### PR DESCRIPTION
Change the type of the RL-grid state-space model from dictionary to SimpleNamespace.

SimpleNamespace allows accessing the elements with dot notation, making the code cleaner, as the methods associated (e.g. keys(), values(), items(), get(), pop() ) with dictionaries are not needed

closes #14 