### PR TITLE
66 refactor control system

### DIFF
--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -1,14 +1,16 @@
 """
 Example of direct model predictive control (MPC) for a grid-connected power converter. MPC is 
 designed as a current controller, thus the main objective is to track the reference of the grid 
-current.
+current. The current references are generated based on the power references. 
 """
 
 #pylint: disable=wrong-import-position
+#pylint: disable=wrong-import-order
 import sys as system
 import os
-
 import numpy as np
+
+from types import SimpleNamespace
 
 ## -------------------------------------------------------------------- ##
 # These allow using soft4pes from this folder
@@ -19,16 +21,17 @@ system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
 ## -------------------------------------------------------------------- ##
 
 from soft4pes import model
-from soft4pes.control import mpc
+from soft4pes.control import mpc, common, lin
 from soft4pes.utils import Sequence
 from soft4pes.sim import Simulation
 
 # Define base values
 base = model.grid.BaseGrid(Vg_R_SI=3300, Ig_R_SI=1575, fg_R_SI=50)
 
-# Define current reference sequence
-i_ref_dq = Sequence(np.array([0, 0.1, 0.1, 1]),
-                    np.array([[1, 0], [1, 0], [0.3, 0.3], [0.3, 0.3]]))
+# Define power reference sequences
+P_ref_seq = Sequence(np.array([0, 0.1, 0.1, 1]), np.array([1, 1, 0, 0]))
+Q_ref_seq = Sequence(np.array([0, 0.1, 0.1, 1]), np.array([0, 0, 0, 0]))
+ref_seq = SimpleNamespace(P_ref_seq=P_ref_seq, Q_ref_seq=Q_ref_seq)
 
 # Define grid parameters
 grid_params = model.grid.RLGridParameters(Vg_SI=3300,
@@ -37,7 +40,7 @@ grid_params = model.grid.RLGridParameters(Vg_SI=3300,
                                           Lg_SI=5.7773e-4,
                                           base=base)
 # Define system models
-sys = model.grid.RLGrid(par=grid_params, base=base, ig_ref_init=i_ref_dq(0))
+sys = model.grid.RLGrid(par=grid_params, base=base)
 conv = model.conv.Converter(v_dc_SI=5200, nl=3, base=base)
 
 # Define solver to be enumeration based
@@ -46,14 +49,15 @@ solver = mpc.solvers.MpcEnum(conv=conv)
 # Uncomment to use Branch-and-Bound solver
 # solver = mpc.solvers.MpcBnB(conv=conv)
 
-# Define controller
-ctr = mpc.controllers.RLGridMpcCurrCtr(solver,
-                                       lambda_u=10e-3,
-                                       Np=1,
-                                       Ts=100e-6,
-                                       i_ref_seq_dq=i_ref_dq)
+# Define controllers, the outer loop generates the grid current reference based on the power
+# references. The inner loop (direct MPC) is used to track the current reference.
+ref_ctr = lin.GridCurrRefGen()
+ctr = mpc.controllers.RLGridMpcCurrCtr(solver, lambda_u=10e-3, Np=1)
+ctrSys = common.ControlSystem(controllers=[ref_ctr, ctr],
+                              ref_seq=ref_seq,
+                              Ts=100e-6)
 
 # Simulate the system
-sim = Simulation(sys=sys, conv=conv, ctr=ctr, Ts_sim=5e-6)
+sim = Simulation(sys=sys, conv=conv, ctr=ctrSys, Ts_sim=5e-6)
 sim.simulate(t_stop=0.2)
 sim.save_data()

--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -49,11 +49,12 @@ solver = mpc.solvers.MpcEnum(conv=conv)
 # Uncomment to use Branch-and-Bound solver
 # solver = mpc.solvers.MpcBnB(conv=conv)
 
-# Define controllers, the outer loop generates the grid current reference based on the power
-# references. The inner loop (direct MPC) is used to track the current reference.
+# Define control loops, the outer loop generates the grid current reference based on the power
+# references, acting as a feedforward term. The inner loop (direct MPC) is used to track the grid
+# current reference.
 ref_ctr = lin.GridCurrRefGen()
 ctr = mpc.controllers.RLGridMpcCurrCtr(solver, lambda_u=10e-3, Np=1)
-ctrSys = common.ControlSystem(controllers=[ref_ctr, ctr],
+ctrSys = common.ControlSystem(control_loops=[ref_ctr, ctr],
                               ref_seq=ref_seq,
                               Ts=100e-6)
 

--- a/examples/grid/rl_grid_state_space_curr_ctr.py
+++ b/examples/grid/rl_grid_state_space_curr_ctr.py
@@ -26,7 +26,7 @@ from soft4pes.sim import Simulation
 base = model.grid.BaseGrid(Vg_R_SI=3300, Ig_R_SI=1575, fg_R_SI=50)
 
 # Define current reference sequence
-i_ref_dq = Sequence(np.array([0, 1]), np.array([[1, 0], [1, 0]]))
+ig_ref_dq = Sequence(np.array([0, 1]), np.array([[1, 0], [1, 0]]))
 
 # Define grid parameters
 grid_params = model.grid.RLGridParameters(Vg_SI=3300,
@@ -36,14 +36,14 @@ grid_params = model.grid.RLGridParameters(Vg_SI=3300,
                                           base=base)
 
 # Define system models
-sys = model.grid.RLGrid(par=grid_params, base=base, ig_ref_init=i_ref_dq(0))
+sys = model.grid.RLGrid(par=grid_params, base=base, ig_ref_init=ig_ref_dq(0))
 conv = model.conv.Converter(v_dc_SI=5529.2, nl=3, base=base)
 
 # Define controller
 ctr = RLGridStateSpaceCurrCtr(sys=sys,
                               base=base,
                               Ts=100e-6,
-                              i_ref_seq_dq=i_ref_dq)
+                              ig_ref_seq_dq=ig_ref_dq)
 
 # Simulate the system
 sim = Simulation(sys=sys, conv=conv, ctr=ctr, Ts_sim=5e-6)

--- a/soft4pes/control/__init__.py
+++ b/soft4pes/control/__init__.py
@@ -3,10 +3,12 @@ Linear and model predictive control (MPC) algorithms for power electronic system
 
 """
 
+from soft4pes.control import common
 from soft4pes.control import lin
 from soft4pes.control import mpc
 
 __all__ = [
+    "common",
     "lin",
     "mpc",
 ]

--- a/soft4pes/control/common/__init__.py
+++ b/soft4pes/control/common/__init__.py
@@ -1,0 +1,11 @@
+"""
+Common control system components.
+"""
+
+from soft4pes.control.common.control_system import ControlSystem
+from soft4pes.control.common.controller import Controller
+
+__all__ = [
+    "ControlSystem",
+    "Controller",
+]

--- a/soft4pes/control/common/control_system.py
+++ b/soft4pes/control/common/control_system.py
@@ -1,25 +1,133 @@
+"""
+Control system class to manage and execute a set of controllers.
+"""
+
 from types import SimpleNamespace
 
 
-class ControlSystem():
+class ControlSystem:
+    """
+    ControlSystem class to manage and execute a set of controllers. The class accepts any number of 
+    controllers and combines them to complete control system.
 
-    def __init__(self, control_loops, ref):
-        self.control_loops = control_loops
-        self.ref = ref
-        self.data = SimpleNamespace(t=[], ref=[])
+    Parameters
+    ----------
+    controllers : list
+        List of controller instances. The controllers are executed in the order they appear in the
+        list. 
+    ref_seq : SimpleNamespace
+        Reference sequences for the control system. The sequences must be of class Sequence. The 
+        references are given to the first controller in the list.
+    Ts : float
+        Sampling interval [s].
+    pwm : modulator, optional
+        Modulator for generating three-phase switch positions.
 
-    def get_control_system_data(self):
-        for controller in self.control_loops:
-            controller_name = controller.__class__.__name__
-            setattr(self.data, controller_name, controller.data)
+    Attributes
+    ----------
+    ref_seq : SimpleNamespace
+        Reference sequences for the controllers. The sequences must be of class Sequence.
+    data : SimpleNamespace
+        Data storage for the control system.
+    Ts : float
+        Sampling interval [s].
+    pwm : modulator, optional
+        Modulator for generating three-phase switch positions.
+    controllers : list
+        List of controller instances.
+    """
+
+    def __init__(self, controllers, ref_seq, Ts, pwm=None):
+        self.ref_seq = ref_seq
+        self.data = SimpleNamespace(t=[])
+        self.Ts = Ts
+        self.pwm = pwm
+        self.controllers = controllers
+        for controller in self.controllers:
+            controller.set_sampling_interval(Ts)
 
     def __call__(self, sys, conv, kTs):
-        ctr_input = self.ref
-        for controller in self.control_loops:
-            controller.get_input(ctr_input)
-            controller.execute(sys, conv, kTs)
-            ctr_input = controller.get_output()
+        """
+        Execute the control system for a given discrete time step. The control system
+        1. Gets the references for the current time step.
+        2. Executes the controllers in the order they appear in the list.
+        3. Generates the three-phase switch position if modulator is used.
+
+        Parameters
+        ----------
+        sys : object
+            System model.
+        conv : object
+            Converter model.
+        kTs : float
+            Current discrete time instant [s].
+
+        Returns
+        -------
+        uk_abc : ndarray
+            Three-phase switch position or modulating signals.
+        """
+
+        # Get the references on step k from the sequences
+        ctr_input = self.get_references(kTs)
+
+        # Execute the controllers
+        for controller in self.controllers:
+            controller.input = ctr_input
+            ctr_input = controller.execute(sys, conv, kTs)
+            controller.save_data()
+
+        self.save_data(kTs=kTs)
+
+        # Form the three-phase switch position if PWM is used, otherwise use feedforward the
+        # output of the last controller
+        if self.pwm is not None:
+            uk_abc = self.pwm(ctr_input)
+        else:
+            uk_abc = ctr_input.uk_abc
+        return uk_abc
+
+    def get_references(self, kTs):
+        """
+        Get the references for the current time step. A new SimpleNamespace object is created and 
+        the '_seq' subscript is removed from the attribute names.
+
+        Parameters
+        ----------
+        kTs : float
+            Current discrete time instant [s].
+
+        Returns
+        -------
+        ref : SimpleNamespace
+            Reference sequences for the control system. The sequences must be of class Sequence. 
+        """
+
+        ref = SimpleNamespace()
+        for key, value in self.ref_seq.__dict__.items():
+            if '_seq' in key:
+                key = key.replace('_seq', '')
+            setattr(ref, key, value(kTs))
+        return ref
 
     def save_data(self, kTs):
+        """
+        Save the current time step to the control system data.
+
+        Parameters
+        ----------
+        kTs : float
+            Current discrete time instant [s].
+        """
+
         self.data.t.append(kTs)
-        self.data.ref.append(self.ref)
+
+    def get_control_system_data(self):
+        """
+        Fetch and save the data of the individual controllers. The data is saved with the name of 
+        the controller class.
+        """
+
+        for controller in self.controllers:
+            controller_name = controller.__class__.__name__
+            setattr(self.data, controller_name, controller.data)

--- a/soft4pes/control/common/control_system.py
+++ b/soft4pes/control/common/control_system.py
@@ -1,0 +1,25 @@
+from types import SimpleNamespace
+
+
+class ControlSystem():
+
+    def __init__(self, control_loops, ref):
+        self.control_loops = control_loops
+        self.ref = ref
+        self.data = SimpleNamespace(t=[], ref=[])
+
+    def get_control_system_data(self):
+        for controller in self.control_loops:
+            controller_name = controller.__class__.__name__
+            setattr(self.data, controller_name, controller.data)
+
+    def __call__(self, sys, conv, kTs):
+        ctr_input = self.ref
+        for controller in self.control_loops:
+            controller.get_input(ctr_input)
+            controller.execute(sys, conv, kTs)
+            ctr_input = controller.get_output()
+
+    def save_data(self, kTs):
+        self.data.t.append(kTs)
+        self.data.ref.append(self.ref)

--- a/soft4pes/control/common/controller.py
+++ b/soft4pes/control/common/controller.py
@@ -1,35 +1,80 @@
+"""
+Base class for controllers.
+"""
+
 from abc import ABC, abstractmethod
 from types import SimpleNamespace
 
 
-class ControllerBase(ABC):
+class Controller(ABC):
     """
     Base class for controllers.
+
+    Attributes
+    ----------
+    data : SimpleNamespace
+        Data storage for the controller, containing input and output namespaces.
+    input : SimpleNamespace
+        Namespace for storing input data.
+    output : SimpleNamespace
+        Namespace for storing output data.
+    Ts : float
+        Sampling interval [s].
     """
 
     def __init__(self):
-        self.data = SimpleNamespace()
+        self.data = SimpleNamespace(
+            input=SimpleNamespace(),
+            output=SimpleNamespace(),
+        )
+        self.input = SimpleNamespace()
+        self.output = SimpleNamespace()
+        self.Ts = 0
 
-    @abstractmethod
-    def input(self, ref):
+    def set_sampling_interval(self, Ts):
         """
-        Get the reference signal for the controller.
+        Set the sampling interval. This method can be extended to set and/or calculate additional 
+        parameters.
+
+        Parameters
+        ----------
+        Ts : float
+            Sampling interval [s].
         """
+        self.Ts = Ts
 
     @abstractmethod
     def execute(self, sys, conv, kTs):
         """
         Execute the controller.
+
+        Parameters
+        ----------
+        sys : object
+            System model.
+        conv : object
+            Converter model.
+        kTs : float
+            Current discrete time instant [s].
+
+        Returns
+        -------
+        output : SimpleNamespace
+            The output of the controller after execution.
         """
 
-    @abstractmethod
-    def output(self):
-        """
-        Get the output signal of the controller.
-        """
-
-    @abstractmethod
-    def save_data(self, kTs):
+    def save_data(self):
         """
         Save controller data.
+
+        The method saves the current input and output data to the data storage.
         """
+        for key, value in self.input.__dict__.items():
+            if not hasattr(self.data.input, key):
+                setattr(self.data.input, key, [])
+            getattr(self.data.input, key).append(value)
+
+        for key, value in self.output.__dict__.items():
+            if not hasattr(self.data.output, key):
+                setattr(self.data.output, key, [])
+            getattr(self.data.output, key).append(value)

--- a/soft4pes/control/common/controller.py
+++ b/soft4pes/control/common/controller.py
@@ -33,8 +33,9 @@ class Controller(ABC):
 
     def set_sampling_interval(self, Ts):
         """
-        Set the sampling interval. This method can be extended to set and/or calculate additional 
-        parameters.
+        Set the sampling interval. 
+        
+        This method can be extended to set and/or calculate additional parameters.
 
         Parameters
         ----------

--- a/soft4pes/control/common/controller.py
+++ b/soft4pes/control/common/controller.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from types import SimpleNamespace
+
+
+class ControllerBase(ABC):
+    """
+    Base class for controllers.
+    """
+
+    def __init__(self):
+        self.data = SimpleNamespace()
+
+    @abstractmethod
+    def input(self, ref):
+        """
+        Get the reference signal for the controller.
+        """
+
+    @abstractmethod
+    def execute(self, sys, conv, kTs):
+        """
+        Execute the controller.
+        """
+
+    @abstractmethod
+    def output(self):
+        """
+        Get the output signal of the controller.
+        """
+
+    @abstractmethod
+    def save_data(self, kTs):
+        """
+        Save controller data.
+        """

--- a/soft4pes/control/lin/__init__.py
+++ b/soft4pes/control/lin/__init__.py
@@ -3,10 +3,12 @@ Linear control algorithms for power electronic systems.
 
 """
 
+from soft4pes.control.lin.grid_curr_ref_gen import GridCurrRefGen
 from soft4pes.control.lin.lin_curr_ctr import RLGridPICurrCtr
 from soft4pes.control.lin.state_space_curr_ctr import RLGridStateSpaceCurrCtr
 
 __all__ = [
+    "GridCurrRefGen",
     "RLGridPICurrCtr",
     "RLGridStateSpaceCurrCtr",
 ]

--- a/soft4pes/control/lin/grid_curr_ref_gen.py
+++ b/soft4pes/control/lin/grid_curr_ref_gen.py
@@ -35,8 +35,8 @@ class GridCurrRefGen(Controller):
         vg = sys.get_grid_voltage(kTs)
         theta = np.arctan2(vg[1], vg[0])
         vg_dq = alpha_beta_2_dq(vg, theta)
-        i_ref_d = self.input.P_ref / vg_dq[0]
-        i_ref_q = -self.input.Q_ref / vg_dq[0]
-        self.output.i_ref_dq = np.array([i_ref_d, i_ref_q])
+        ig_ref_d = self.input.P_ref / vg_dq[0]
+        ig_ref_q = -self.input.Q_ref / vg_dq[0]
+        self.output.ig_ref_dq = np.array([ig_ref_d, ig_ref_q])
 
         return self.output

--- a/soft4pes/control/lin/grid_curr_ref_gen.py
+++ b/soft4pes/control/lin/grid_curr_ref_gen.py
@@ -1,0 +1,42 @@
+"""
+Grid current reference generator.
+"""
+
+import numpy as np
+from soft4pes.control.common import Controller
+from soft4pes.utils import alpha_beta_2_dq
+
+
+class GridCurrRefGen(Controller):
+    """
+    Grid current reference generator. This class generates the grid current reference based on the 
+    active and reactive power references using grid voltage.
+    """
+
+    def execute(self, sys, conv, kTs):
+        """
+        Generate the current reference.
+
+        Parameters
+        ----------
+        sys : object
+            System model.
+        conv : object
+            Converter model.
+        kTs : float
+            Current discrete time instant [s].
+
+        Returns
+        -------
+        output : SimpleNamespace
+            The output of the controller, containing the current reference in dq frame.
+        """
+
+        vg = sys.get_grid_voltage(kTs)
+        theta = np.arctan2(vg[1], vg[0])
+        vg_dq = alpha_beta_2_dq(vg, theta)
+        i_ref_d = self.input.P_ref / vg_dq[0]
+        i_ref_q = -self.input.Q_ref / vg_dq[0]
+        self.output.i_ref_dq = np.array([i_ref_d, i_ref_q])
+
+        return self.output

--- a/soft4pes/control/lin/grid_curr_ref_gen.py
+++ b/soft4pes/control/lin/grid_curr_ref_gen.py
@@ -10,7 +10,9 @@ from soft4pes.utils import alpha_beta_2_dq
 class GridCurrRefGen(Controller):
     """
     Grid current reference generator. This class generates the grid current reference based on the 
-    active and reactive power references using grid voltage.
+    active and reactive power references using grid voltage. The equations are in per unit. Grid 
+    voltage orientation is assumed, i.e. vg_d is aligned with d-axis of the dq-reference frame. 
+    Moreover, the positive grid current flows from the converter to the grid.
     """
 
     def execute(self, sys, conv, kTs):
@@ -36,7 +38,7 @@ class GridCurrRefGen(Controller):
         theta = np.arctan2(vg[1], vg[0])
         vg_dq = alpha_beta_2_dq(vg, theta)
         ig_ref_d = self.input.P_ref / vg_dq[0]
-        ig_ref_q = -self.input.Q_ref / vg_dq[0]
+        ig_ref_q = self.input.Q_ref / vg_dq[0]
         self.output.ig_ref_dq = np.array([ig_ref_d, ig_ref_q])
 
         return self.output

--- a/soft4pes/control/lin/lin_curr_ctr.py
+++ b/soft4pes/control/lin/lin_curr_ctr.py
@@ -43,7 +43,7 @@ class RLGridPICurrCtr:
         Current error instance in q-frame [p.u.].                               
     i_ref_seq_dq : Sequence object
         Current reference sequence instance in dq-frame [p.u.].   
-    sim_data : dict
+    data : dict
         Controller data.
     """
 
@@ -59,7 +59,7 @@ class RLGridPICurrCtr:
         self.integral_error_q = 0
         self.i_ref_seq_dq = i_ref_seq_dq
 
-        self.sim_data = {
+        self.data = {
             'ig_ref': [],
             'u': [],
             't': [],
@@ -153,6 +153,12 @@ class RLGridPICurrCtr:
         kTs : float
             Current discrete time instant [s].
         """
-        self.sim_data['ig_ref'].append(ig_ref)
-        self.sim_data['u'].append(uk_abc)
-        self.sim_data['t'].append(kTs)
+        self.data['ig_ref'].append(ig_ref)
+        self.data['u'].append(uk_abc)
+        self.data['t'].append(kTs)
+
+    def get_control_system_data(self):
+        """
+        This is a empty method to make different controllers compatible when building the new 
+        control system structure.
+        """

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -93,7 +93,8 @@ class RLGridStateSpaceCurrCtr:
         # Maximum converter output voltage
         u_max = conv.v_dc / 2
 
-        # Assume filter capacitor voltage equals grid voltage (No filter considered)
+        # As the filter is not concidered, the filter capacitor voltage is assumed to be the same
+        # as the grid voltage after the grid indutance.
         uf_dq = vg
 
         # Compute the converter voltage reference using the state space controller with anti-windup

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -19,7 +19,7 @@ class RLGridStateSpaceCurrCtr:
         Base values.
     Ts : float
         Sampling interval [s].
-    i_ref_seq_dq : Sequence object
+    ig_ref_seq_dq : Sequence object
         Current reference sequence instance in dq-frame [p.u.].
 
     Attributes
@@ -38,13 +38,13 @@ class RLGridStateSpaceCurrCtr:
         Converter voltage reference after current controller integrator in dq frame [p.u.].
     uc_km1_dq : 1 x 2 ndarray of floats
         Previous converter voltage reference in dq frame [p.u.].                                    
-    i_ref_seq_dq : Sequence object
+    ig_ref_seq_dq : Sequence object
         Current reference sequence instance in dq-frame [p.u.].   
     data : dict
         Controller data.
     """
 
-    def __init__(self, sys, base, Ts, i_ref_seq_dq):
+    def __init__(self, sys, base, Ts, ig_ref_seq_dq):
         self.Xf = sys.par.Xg  # Assume the inductances are equal
         self.Rf = sys.par.Rg  # Assume the resitances are equal
         self.Ts = Ts
@@ -52,7 +52,7 @@ class RLGridStateSpaceCurrCtr:
         self.ctr_pars = self.get_state_space_ctr_pars()
         self.u_ii_dq = np.zeros(2)
         self.uc_km1_dq = np.zeros(2)
-        self.i_ref_seq_dq = i_ref_seq_dq
+        self.ig_ref_seq_dq = ig_ref_seq_dq
 
         self.data = {
             'ig_ref': [],
@@ -82,7 +82,7 @@ class RLGridStateSpaceCurrCtr:
         vg = sys.get_grid_voltage(kTs)
 
         # Get the reference for current step
-        ic_ref_dq = self.i_ref_seq_dq(kTs)
+        ic_ref_dq = self.ig_ref_seq_dq(kTs)
 
         # Calculate the transformation angle
         theta = np.arctan2(vg[1], vg[0])

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -40,7 +40,7 @@ class RLGridStateSpaceCurrCtr:
         Previous converter voltage reference in dq frame [p.u.].                                    
     i_ref_seq_dq : Sequence object
         Current reference sequence instance in dq-frame [p.u.].   
-    sim_data : dict
+    data : dict
         Controller data.
     """
 
@@ -54,7 +54,7 @@ class RLGridStateSpaceCurrCtr:
         self.uc_km1_dq = np.zeros(2)
         self.i_ref_seq_dq = i_ref_seq_dq
 
-        self.sim_data = {
+        self.data = {
             'ig_ref': [],
             'u': [],
             't': [],
@@ -231,6 +231,12 @@ class RLGridStateSpaceCurrCtr:
         kTs : float
             Current discrete time instant [s].
         """
-        self.sim_data['ig_ref'].append(ig_ref)
-        self.sim_data['u'].append(uk_abc)
-        self.sim_data['t'].append(kTs)
+        self.data['ig_ref'].append(ig_ref)
+        self.data['u'].append(uk_abc)
+        self.data['t'].append(kTs)
+
+    def get_control_system_data(self):
+        """
+        This is a empty method to make different controllers compatible when building the new 
+        control system structure.
+        """

--- a/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
@@ -42,7 +42,7 @@ class IMMpcCurrCtr:
         The state-space model of the system.
     C : 2 x 4 ndarray of ints
         Output matrix.
-    sim_data : dict
+    data : dict
         Controller data.
     """
 
@@ -58,7 +58,7 @@ class IMMpcCurrCtr:
         # Output matrix
         self.C = np.array([[1, 0, 0, 0], [0, 1, 0, 0]])
 
-        self.sim_data = {
+        self.data = {
             'u': [],
             'iS_ref': [],
             't': [],
@@ -152,7 +152,13 @@ class IMMpcCurrCtr:
         kTs : float
             Current discrete time instant [s].
         """
-        self.sim_data['iS_ref'].append(iS_ref)
-        self.sim_data['u'].append(uk_abc)
-        self.sim_data['T_ref'].append(T_ref)
-        self.sim_data['t'].append(kTs)
+        self.data['iS_ref'].append(iS_ref)
+        self.data['u'].append(uk_abc)
+        self.data['T_ref'].append(T_ref)
+        self.data['t'].append(kTs)
+
+    def get_control_system_data(self):
+        """
+        This is a empty method to make different controllers compatible when building the new 
+        control system structure.
+        """

--- a/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
@@ -1,4 +1,6 @@
-""" Model predictive current control (MPC) for RL grid."""
+"""
+Model predictive control (MPC) for the control of the grid current (RL grid).
+"""
 
 from types import SimpleNamespace
 import numpy as np

--- a/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
@@ -76,11 +76,11 @@ class RLGridMpcCurrCtr(Controller):
         self.vg = sys.get_grid_voltage(kTs)
 
         # Get the reference for current step
-        i_ref_dq = self.input.i_ref_dq
+        ig_ref_dq = self.input.ig_ref_dq
 
         # Get the grid-voltage angle and calculate the reference in alpha-beta frame
         theta = np.arctan2(self.vg[1], self.vg[0])
-        ig_ref = dq_2_alpha_beta(i_ref_dq, theta)
+        ig_ref = dq_2_alpha_beta(ig_ref_dq, theta)
 
         # Predict the current reference over the prediction horizon
         # Make a rotation matrix

--- a/soft4pes/sim/simulation.py
+++ b/soft4pes/sim/simulation.py
@@ -121,7 +121,9 @@ class Simulation:
 
             progress_printer(k)
 
-        self.simulation_data = {'ctr': self.ctr.sim_data, 'sys': self.sys.data}
+        # Get the simulation data
+        self.ctr.get_control_system_data()
+        self.simulation_data = {'ctr': self.ctr.data, 'sys': self.sys.data}
 
     def save_data(self, filename='sim_data.mat', path=''):
         """


### PR DESCRIPTION
This PR implements a new structure for the control system. The main functionalities are:
- Having a common base class for all controllers
- Making a modular control system, that supports any number of control loops

The `control` package now has a new subpackage, `common`. This package includes common modules (files) for all controllers. Two new modules have been added:
- `Controller`: This module implements a common base class for all controllers. The common functionalities mainly include attributes `input` and `output`, which act as a common interface for all controllers. In addition, the module includes data saving functionalities. Set sampling interval function is used to set the sampling interval, but it can be expanded to initialize other control parameters (i.e. PI-controller gains based on `Ts`).
- `ControlSystem`: This module is used to build a whole control system, consisting of one or more control loops (cascade structure) and a modulator (not available yet). The controllers are given to the ControlSystem as a list, and the first controller in the list presents the outmost loop. The last controller in the list outputs the three-phase modulating signal or the three phase switch position. Other functionalities of the module are data saving and getting the current references from the reference sequences. 
- (see more text under the figures)

![image](https://github.com/user-attachments/assets/448fd95e-fde0-497c-acf8-0e02f63c83c8)

![image](https://github.com/user-attachments/assets/4ceb03ba-cfc8-419c-ba94-9b7526a79a04)

Some notes about the PR:
- The new control system has been implemented for only `RLGridMpcCurrCtr`. The reason for this is getting feedback before changing all the controllers.
- To make different control systems compatible, a empty function `def get_control_system_data(self):` has been added to the controllers with the old style.
- The example `rl_grid_direct_mpc_curr_ctr.py` now includes also grid current reference generation based on the power references. This is mainly to demonstrate and test that multiple loops can be connected, The function can be later removed/improved.
- Due to renaming variables, many files have changed. The most important ones and the ones to concentrate your attention on are: `rl_grid_direct_mpc_curr_ctr.py`, `controller.py`, `control_system.py`, and `rl_grid_mpc_curr_ctr.py`. 
- The examples run as expected, no exhaustive testing needed.

closes #66 
