### PR TITLE
74 implement indirect mpc

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,7 @@
 numpy
 scipy
 matplotlib
+qpsolvers[daqp]
 numpydoc
 sphinx==6.2.1
 sphinx-autoapi

--- a/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
+++ b/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
@@ -1,0 +1,66 @@
+"""
+Example of model predictive control (MPC) for a grid-connected power converter with an LC(L) filter.
+MPC is designed as a capacitor voltage controller, thus the main objective is to track the
+capacitor voltage reference, while limiting the converter current. 
+"""
+
+#pylint: disable=wrong-import-position
+#pylint: disable=wrong-import-order
+import sys as system
+import os
+import numpy as np
+
+from types import SimpleNamespace
+
+## -------------------------------------------------------------------- ##
+# These allow using soft4pes from this folder
+# Get the directory of the current file and add the grandparent directory
+# (soft4pes) to the path
+current_dir = os.path.dirname(os.path.abspath(__file__))
+system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
+## -------------------------------------------------------------------- ##
+
+from soft4pes import model
+from soft4pes.control import mpc, common
+from soft4pes.utils import Sequence
+from soft4pes.sim import Simulation
+
+# Define base values
+base = model.grid.BaseGrid(Vg_R_SI=400, Ig_R_SI=18, fg_R_SI=50)
+
+# Define capacitor voltage reference sequences
+vc_ref_dq_seq = Sequence(np.array([0, 1]), np.array([[1, 0], [1, 0]]))
+ref_seq = SimpleNamespace(vc_ref_dq_seq=vc_ref_dq_seq)
+
+# Define grid parameters and filter parameters
+grid_params = model.grid.RLGridParameters(Vg_SI=400,
+                                          fg_SI=50,
+                                          Rg_SI=0.01,
+                                          Lg_SI=5e-3,
+                                          base=base)
+lcl_params = model.grid.LCLFilterParameters(R_fc_SI=0.1,
+                                            L_fc_SI=3e-3,
+                                            C_SI=10e-6,
+                                            R_c_SI=1e-3,
+                                            base=base)
+
+# Define system models
+sys = model.grid.RLGridLCLFilter(par_grid=grid_params,
+                                 par_lcl_filter=lcl_params,
+                                 base=base)
+conv = model.conv.Converter(v_dc_SI=650, nl=2, base=base)
+
+# Formulate and solve the problem as a QP. Indirect MPC is used.
+solver = mpc.solvers.IndirectMpcQP()
+
+# Uncomment to use direct MPC with branch-and-bound solver
+# solver = mpc.solvers.MpcBnB(conv=conv)
+
+# Define the controller
+ctr = mpc.controllers.LCLVcMpcCtr(solver=solver, lambda_u=1e-4, Np=4)
+ctrSys = common.ControlSystem(control_loops=[ctr], ref_seq=ref_seq, Ts=100e-6)
+
+# Simulate the system
+sim = Simulation(sys=sys, conv=conv, ctr=ctrSys, Ts_sim=5e-6)
+sim.simulate(t_stop=0.2)
+sim.save_data()

--- a/soft4pes/control/mpc/controllers/__init__.py
+++ b/soft4pes/control/mpc/controllers/__init__.py
@@ -3,10 +3,12 @@ Model predictive control (MPC) for power electronic systems.
 
 """
 
-from soft4pes.control.mpc.controllers.rl_grid_mpc_curr_ctr import RLGridMpcCurrCtr
+from soft4pes.control.mpc.controllers.lcl_vc_mpc_ctr import LCLVcMpcCtr
 from soft4pes.control.mpc.controllers.im_mpc_curr_ctr import IMMpcCurrCtr
+from soft4pes.control.mpc.controllers.rl_grid_mpc_curr_ctr import RLGridMpcCurrCtr
 
 __all__ = [
-    "RLGridMpcCurrCtr",
+    "LCLVcMpcCtr",
     "IMMpcCurrCtr",
+    "RLGridMpcCurrCtr",
 ]

--- a/soft4pes/control/mpc/controllers/lcl_vc_mpc_ctr.py
+++ b/soft4pes/control/mpc/controllers/lcl_vc_mpc_ctr.py
@@ -1,0 +1,160 @@
+"""
+Model predictive control (MPC) for the control of the capacitor voltage. 
+"""
+
+from types import SimpleNamespace
+import numpy as np
+from soft4pes.utils import dq_2_alpha_beta
+from soft4pes.control.common.controller import Controller
+
+
+class LCLVcMpcCtr(Controller):
+    """
+    Model predictive control (MPC) for the control of the capacitor voltage.
+
+    Parameters
+    ----------
+    solver : solver object
+        Solver for an MPC algorithm.
+    lambda_u : float
+        Weighting factor for the control effort.
+    Np : int
+        Prediction horizon steps.
+    I_conv_max : float
+        Maximum converter current [p.u.].
+    xi_I_conv : float
+        Slack variable weight for the current constraint.
+
+    Attributes
+    ----------
+    solver : solver object
+        Solver for MPC.
+    lambda_u : float
+        Weighting factor for the control effort.
+    Np : int
+        Prediction horizon.
+    u_km1_abc : 1 x 3 ndarray of floats
+        Previous (step k-1) three-phase switch position or modulating signal.
+    state_space : SimpleNamespace
+        The state-space model of the system.
+    vg : 1 x 2 ndarray of floats
+        Grid voltage [p.u.].
+    R : 1 x 1 ndarray of floats
+        Weight matrix for the soft constraints.
+    c : 1 x 1 ndarray of floats
+        State constraints.
+    C_constr : 2 x 6 ndarray of ints
+        Output matrix for the constrained states.
+    C : 2 x 6 ndarray of ints
+        System output matrix.
+    Q : 2 x 2 ndarray of ints
+        Weighting matrix for the output variables.
+    """
+
+    def __init__(self, solver, lambda_u, Np, I_conv_max=1.2, xi_I_conv=1e6):
+        super().__init__()
+        self.solver = solver
+        self.lambda_u = lambda_u
+        self.Np = Np
+        self.u_km1_abc = np.array([0, 0, 0])
+        self.state_space = SimpleNamespace()
+        self.vg = np.array([0, 0])
+
+        # Weight matrix for the constraints (R) and vector for state constraints (c)
+        self.R = np.array([[xi_I_conv]])
+        self.c = np.array([[I_conv_max]])
+
+        # Output matrix for the constrained states
+        self.C_constr = np.block(
+            [np.eye(2), np.zeros((2, 2)),
+             np.zeros((2, 2))])
+
+        # Output matrix (C) and weighting matrix (Q) for the output variables
+        self.C = np.block([[np.zeros((2, 2)), np.zeros((2, 2)), np.eye(2)]])
+        self.Q = np.eye(2)
+
+    def execute(self, sys, conv, kTs):
+        """
+        Perform MPC and save the controller data.
+
+        Parameters
+        ----------
+        sys : system object
+            System model.
+        conv : converter object
+            Converter model.
+        kTs : float
+            Current discrete time instant [s].
+
+        Returns
+        -------
+        SimpleNamespace
+            SimpleNameSpace containing the converter three-phase switch position or modulating 
+            signal.
+        """
+
+        # Get the discrete state-space model of the system
+        self.state_space = sys.get_discrete_state_space(conv.v_dc, self.Ts)
+
+        # Get the grid voltage and save it for future use
+        self.vg = sys.get_grid_voltage(kTs)
+
+        # Get the reference at step k
+        vc_ref_dq = self.input.vc_ref_dq
+
+        # Get the grid-voltage angle and calculate the reference in alpha-beta frame
+        theta = np.arctan2(self.vg[1], self.vg[0])
+        vc_ref = dq_2_alpha_beta(vc_ref_dq, theta)
+
+        # Make a rotation matrix
+        Ts_pu = self.Ts * sys.base.w
+        delta_theta = sys.par.wg * Ts_pu
+        R_rot = np.array([[np.cos(delta_theta), -np.sin(delta_theta)], \
+                          [np.sin(delta_theta), np.cos(delta_theta)]])
+
+        # Predict the output (capacitor voltage) reference within the horizon based on the reference
+        # value at step k
+        y_ref = np.zeros((self.Np + 1, 2))
+        y_ref[0, :] = vc_ref
+        for ell in range(self.Np):
+            y_ref[ell + 1, :] = np.dot(R_rot, y_ref[ell, :])
+
+        # Solve the control problem
+        uk_abc = self.solver(sys, conv, self, y_ref)
+        self.u_km1_abc = uk_abc
+
+        self.output = SimpleNamespace(uk_abc=uk_abc)
+
+        return self.output
+
+    def get_next_state(self, sys, xk, uk_abc, k):
+        """
+        Get the next state of the system.
+
+        Parameters
+        ----------
+        sys : system object
+            The system model.
+        xk : 1 x 6 ndarray of floats
+            The current state of the system.
+        uk_abc : 1 x 3 ndarray of floats
+            Converter three-phase switch position or modulating signal.
+        k : int
+            The solver prediction step.
+
+        Returns
+        -------
+        1 x 6 ndarray of floats
+            The next state of the system.
+        """
+
+        # Get the grid voltage at step k by rotating it
+        Ts_pu = self.Ts * sys.base.w
+        delta_theta = k * sys.par.wg * Ts_pu
+        R = np.array([[np.cos(delta_theta), -np.sin(delta_theta)], \
+                        [np.sin(delta_theta), np.cos(delta_theta)]])
+
+        vg_k = np.dot(R, self.vg)
+
+        return np.dot(self.state_space.A, xk) + np.dot(
+            self.state_space.B1, uk_abc) + np.dot(self.state_space.B2, vg_k)

--- a/soft4pes/control/mpc/solvers/__init__.py
+++ b/soft4pes/control/mpc/solvers/__init__.py
@@ -3,10 +3,22 @@ Solvers for model predictive control (MPC) algorithms.
 
 """
 
+from soft4pes.control.mpc.solvers.mpc_QP import IndirectMpcQP
 from soft4pes.control.mpc.solvers.mpc_bnb import MpcBnB
 from soft4pes.control.mpc.solvers.mpc_enum import MpcEnum
+from soft4pes.control.mpc.solvers.utils import (
+    switching_constraint_violated,
+    make_QP_matrices,
+    make_Gamma,
+    make_Upsilon,
+)
 
 __all__ = [
+    'IndirectMpcQP',
     'MpcBnB',
     'MpcEnum',
+    'switching_constraint_violated',
+    'make_QP_matrices',
+    'make_Gamma',
+    'make_Upsilon',
 ]

--- a/soft4pes/control/mpc/solvers/mpc_QP.py
+++ b/soft4pes/control/mpc/solvers/mpc_QP.py
@@ -1,0 +1,96 @@
+"""
+This module contains the class MpcQP, which is used to solve the MPC problem using a quadratic 
+program (QP) solver. 
+
+The formulation of the control problem and the QP matrices are based on "M. Rossi, P. Karamanakos, 
+and F. Castelli-Dezza, “An indirect model predictive control method for grid-connected three-level 
+neutral point clamped converters with LCL filters,” IEEE Trans. Ind. Applicat., vol. 58, no. 3, pp. 
+3750-3768, May/Jun. 2022". Note, that contrary to the reference, the grid voltage is modelled as a 
+disturbance. Moreover, the same states do not have to be both controlled (i.e., be output variables)
+and constrained.
+
+The QP is solved using the qpsolvers package and the solver 'DAQP', licensed under the MIT 
+license.
+"""
+
+import numpy as np
+from qpsolvers import solve_qp
+from soft4pes.control.mpc.solvers.utils import make_QP_matrices
+
+
+class IndirectMpcQP:
+    """
+    Problem formulation and QP solver for indirect MPC. 
+
+    Attributes
+    ----------
+    QP_matrices : SimpleNamespace
+        Namespace containing the matrices used in the QP problem.
+    """
+
+    def __init__(self):
+        self.QP_matrices = None
+
+    def __call__(self, sys, conv, ctr, y_ref):
+        """
+        Formulate and solve the MPC QP.
+
+        Parameters
+        ----------
+        sys : system object
+            System model.
+        conv : converter object
+            Converter model.
+        ctr : controller object
+            Controller object.
+        y_ref : ndarray of floats
+            Reference vector [p.u.].
+
+        Returns
+        -------
+        uk_abc : 1 x 3 ndarray of floats
+            The three-phase modulating signal.
+        """
+
+        if self.QP_matrices is None:
+            self.QP_matrices = make_QP_matrices(sys, conv, ctr)
+
+        m = self.QP_matrices
+
+        # Reshape the vectors to be row vectors
+        x = sys.x.reshape(-1, 1)
+        y_ref = y_ref[1:].flatten().reshape(-1, 1)
+        u_km1 = ctr.u_km1_abc.reshape(-1, 1)
+
+        # Formulate the time varying matrice Theta
+        Theta = -m.Upsilon.T.dot(m.Q_tilde).dot(
+            y_ref - m.Gamma.dot(x)) - ctr.lambda_u * m.S.T.dot(m.E).dot(u_km1)
+
+        # If the system is a grid-connected converter, predict the grid voltage. This formulation of
+        # Theta differs from the reference, as the grid voltage is modelled here as a disturbance.
+        if m.Psi is not None:
+            Ts_pu = ctr.Ts * sys.base.w
+            delta_theta = sys.par.wg * Ts_pu
+            R_vg = np.array([[np.cos(delta_theta), -np.sin(delta_theta)], \
+                            [np.sin(delta_theta), np.cos(delta_theta)]])
+
+            Vg = np.zeros((ctr.Np * 2, 1))
+            Vg[0:2] = ctr.vg.reshape(-1, 1)
+            for k in range(2, ctr.Np * 2, 2):
+                Vg[k:k + 2] = np.dot(R_vg, Vg[k - 2:k])
+
+            Theta = Theta + m.Upsilon.T.dot(m.Psi).dot(Vg)
+
+        # Form the time varying linear objective vector d
+        d = np.vstack([Theta, np.zeros((m.R_size * ctr.Np, 1))])
+
+        # Form the time varying linear inequality constraint vector
+        b_QP = np.vstack([
+            np.ones((6 * ctr.Np, 1)),
+            m.Delta - m.Pi.dot(m.Gamma_constraints).dot(x)
+        ])
+
+        # Solve the QP and return the solution to the controller
+        U_tilde = solve_qp(m.H_tilde, d, m.A_QP, b_QP, solver='daqp')
+
+        return U_tilde[0:3]

--- a/soft4pes/control/mpc/solvers/utils.py
+++ b/soft4pes/control/mpc/solvers/utils.py
@@ -1,6 +1,7 @@
 """Utility functions for MPC solvers."""
 
 import numpy as np
+from types import SimpleNamespace
 
 
 def switching_constraint_violated(nl, uk_abc, u_km1_abc):
@@ -30,3 +31,163 @@ def switching_constraint_violated(nl, uk_abc, u_km1_abc):
         res = np.linalg.norm(uk_abc - u_km1_abc, np.inf) >= 2
 
     return res
+
+
+def make_QP_matrices(sys, conv, ctr):
+    """
+    Create the QP matrices.
+
+    Parameters
+    ----------
+    sys : system object
+        System model.
+    conv : converter object
+        Converter model.
+    ctr : controller object
+        Controller object.
+
+    Returns
+    -------
+    SimpleNamespace
+        Namespace containing the QP matrices.
+    """
+
+    model = sys.get_discrete_state_space(conv.v_dc, ctr.Ts)
+    A_QP = model.A
+    C = ctr.C
+
+    Np = ctr.Np
+    lambda_u = ctr.lambda_u
+    R_size = np.size(ctr.R, 1)
+
+    Q_tilde = np.kron(np.eye(Np), ctr.Q)
+    R_tilde = np.kron(np.eye(Np), ctr.R)
+
+    S = np.eye(3 * Np) - np.block([[np.zeros(
+        (3, 3 * Np))], [np.eye(3 * (Np - 1)),
+                        np.zeros((3 * (Np - 1), 3))]])
+    E = np.block([[np.eye(3)], [np.zeros(((Np - 1) * 3, 3))]])
+
+    Gamma = make_Gamma(Np, C, A_QP)
+    Gamma_constraints = make_Gamma(Np, ctr.C_constr, A_QP)
+
+    # If the system is a grid-connected converter, take into account the grid voltage that has
+    # been modelled as a disturbance. Note that contrary to the reference paper, the constraints
+    # are handled separately of the output variables.
+    if hasattr(model, 'B1'):
+        B1 = model.B1
+        B2 = model.B2
+        Upsilon = make_Upsilon(Np, C, A_QP, B1)
+        Upsilon_constraints = make_Upsilon(Np, ctr.C_constr, A_QP, B1)
+        Psi = make_Upsilon(Np, C, A_QP, B2)
+    else:
+        B = model.B
+        Upsilon = make_Upsilon(Np, C, A_QP, B)
+        Upsilon_constraints = make_Upsilon(Np, ctr.C_constr, A_QP, B)
+        Psi = None
+
+    # Form the quadric objective matrix H_tilde
+    H = Upsilon.T.dot(Q_tilde).dot(Upsilon) + lambda_u * S.T.dot(S)
+    H_tilde = np.block([[H, np.zeros((3 * Np, R_size * Np))],
+                        [np.zeros((R_size * Np, 3 * Np)), R_tilde]])
+
+    K_inv = np.array([[1, 0], [-1 / 2, np.sqrt(3) / 2],
+                      [-1 / 2, -np.sqrt(3) / 2]])
+    K_inv_tilde = np.kron(np.eye(R_size), K_inv)
+
+    W = np.array([[1, -1, 0, 0, 0, 0, 0],\
+                    [0, 0, 1, -1, 0, 0, 0],
+                    [0, 0, 0, 0, 1, -1, 0]]).T
+    W_tilde = np.kron(np.eye(R_size), W)
+
+    N = np.kron(np.eye(R_size), np.block([[np.ones((6, 1))], [0]]))
+
+    Nc = np.dot(N, ctr.c)
+
+    M = np.kron(np.eye(R_size), np.ones((7, 1)))
+
+    Z = np.kron(np.eye(Np), -M)
+
+    Pi = np.kron(np.eye(Np), np.dot(W_tilde, K_inv_tilde))
+
+    Delta = np.kron(np.ones((Np, 1)), Nc)
+
+    V = np.array(
+        [[1, 0, 0, -1, 0, 0],\
+            [0, 1, 0, 0, -1, 0],\
+            [0, 0, 1, 0, 0, -1]]).T
+
+    Omega = np.kron(np.eye(Np), V)
+
+    # Form the linear inequality constraint matrix A_QP
+    A_QP = np.block([[Omega, np.zeros((6 * Np, R_size * Np))],
+                     [np.dot(Pi, Upsilon_constraints), Z]])
+
+    return SimpleNamespace(R_size=R_size,
+                           Gamma=Gamma,
+                           Gamma_constraints=Gamma_constraints,
+                           Upsilon=Upsilon,
+                           S=S,
+                           E=E,
+                           H_tilde=H_tilde,
+                           Q_tilde=Q_tilde,
+                           Delta=Delta,
+                           Pi=Pi,
+                           A_QP=A_QP,
+                           Psi=Psi)
+
+
+def make_Gamma(Np, C, A):
+    """
+    Make Gamma matrix for the QP.
+
+    Parameters
+    ----------
+    Np : int
+        Prediction horizon.
+    C : ndarray
+        Output matrix of the system.
+    A : ndarray
+        State matrix of the system.
+
+    Returns
+    -------
+    ndarray
+        Gamma matrix.
+    """
+    Gamma = np.zeros((Np * C.shape[0], A.shape[1]))
+    for i in range(0, Np):
+        Gamma_row_index = range(i * C.shape[0], (i + 1) * C.shape[0])
+        Gamma[Gamma_row_index] = np.dot(C, np.linalg.matrix_power(A, i + 1))
+    return Gamma
+
+
+def make_Upsilon(Np, C, A, B):
+    """
+    Make Upsilon matrix for the QP.
+
+    Parameters
+    ----------
+    Np : int
+        Prediction horizon.
+    C : ndarray
+        Output matrix of the system.
+    A : ndarray
+        State matrix of the system.
+    B : ndarray
+        Input matrix of the system.
+
+    Returns
+    -------
+    ndarray
+        Upsilon matrix.
+    """
+    Upsilon = np.zeros((Np * C.shape[0], Np * B.shape[1]))
+    Upsilon_row = np.zeros((C.shape[0], Np * B.shape[1]))
+    for i in range(Np):
+        Upsilon_row = np.roll(Upsilon_row, B.shape[1], axis=1)
+        Upsilon_row[:, :B.shape[1]] = C.dot(np.linalg.matrix_power(A,
+                                                                   i)).dot(B)
+        Upsilon_row_index = range(i * C.shape[0], (i + 1) * C.shape[0])
+        Upsilon[Upsilon_row_index] = Upsilon_row
+    return Upsilon

--- a/soft4pes/model/grid/rl_grid_lcl_filter.py
+++ b/soft4pes/model/grid/rl_grid_lcl_filter.py
@@ -81,16 +81,16 @@ class RLGridLCLFilter(RLGrid):
                                 [0, np.sqrt(3) / 2, -np.sqrt(3) / 2]])
 
         F11 = (-R1 / X_fc) * np.eye(2)
-        F12 = (-1 / X_fc) * np.eye(2)
-        F13 = (Rc / X_fc) * np.eye(2)
+        F13 = (-1 / X_fc) * np.eye(2)
+        F12 = (Rc / X_fc) * np.eye(2)
 
-        F21 = (1 / Xc) * np.eye(2)
-        F22 = np.zeros((2, 2))
-        F23 = (-1 / Xc) * np.eye(2)
+        F31 = (1 / Xc) * np.eye(2)
+        F33 = np.zeros((2, 2))
+        F32 = (-1 / Xc) * np.eye(2)
 
-        F31 = (Rc / X) * np.eye(2)
-        F32 = (1 / X) * np.eye(2)
-        F33 = (-R2 / X) * np.eye(2)
+        F21 = (Rc / X) * np.eye(2)
+        F23 = (1 / X) * np.eye(2)
+        F22 = (-R2 / X) * np.eye(2)
 
         F = np.block([
             [F11, F12, F13],
@@ -101,7 +101,9 @@ class RLGridLCLFilter(RLGrid):
         G1 = (v_dc / (2 * X_fc)) * np.dot(
             np.block([[np.eye(2), np.zeros((2, 4))]]).T, K)
 
-        G2 = np.block([[np.eye(2, 4), -1 / X * np.eye(2)]]).T
+        G2 = np.block(
+            [[np.zeros((2, 2)), -1 / X * np.eye(2),
+              np.zeros((2, 2))]]).T
 
         # Discretize the system using exact discretization
         A = expm(F * Ts_pu)


### PR DESCRIPTION
This PR implements indirect MPC for capacitor voltage reference tracking. The functionality of the controller has been verified.

When reviewing, I would suggest omitting the generation of the most complex problem matrices, as going through the generation of i.e. Ypsilon would be challenging.

closes #74 