### PR TITLE
Add discretization method choosing

### DIFF
--- a/examples/grid/grid_forming_ctr.py
+++ b/examples/grid/grid_forming_ctr.py
@@ -57,10 +57,8 @@ lcl_params = model.grid.LCLFilterParameters(L_fc_SI=3e-3,
                                             base=base)
 
 # Define the system model
-sys = model.grid.RLGridLCLFilter(grid_params, lcl_params, base)
-
-# Define the converter properties
 conv = model.conv.Converter(v_dc_SI=750, nl=2, base=base)
+sys = model.grid.RLGridLCLFilter(grid_params, lcl_params, conv, base)
 
 # Build the reference-feedforward power synchronization control (RFPSC)
 rfpsc = lin.RFPSC(sys)
@@ -88,7 +86,7 @@ ctr_sys = common.ControlSystem(control_loops=control_loops,
                                Ts=100e-6)
 
 # Simulate the system
-sim = Simulation(sys=sys, conv=conv, ctr=ctr_sys, Ts_sim=5e-6)
+sim = Simulation(sys=sys, ctr=ctr_sys, Ts_sim=5e-6)
 sim_data = sim.simulate(t_stop=0.5)
 
 # Save the simulation data to a .mat file

--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -38,8 +38,8 @@ grid_params = model.grid.RLGridParameters(Vg_SI=3300,
                                           Lg_SI=5.7773e-4,
                                           base=base)
 # Define system models
-sys = model.grid.RLGrid(par=grid_params, base=base)
 conv = model.conv.Converter(v_dc_SI=5200, nl=3, base=base)
+sys = model.grid.RLGrid(grid_params, conv, base)
 
 # Define solver to be enumeration based
 solver = mpc.solvers.MpcEnum(conv=conv)
@@ -51,12 +51,12 @@ solver = mpc.solvers.MpcEnum(conv=conv)
 # references, acting as a feedforward term. The inner loop (direct MPC) is used to track the grid
 # current reference.
 ref_ctr = lin.GridCurrRefGen()
-ctr = mpc.controllers.RLGridMpcCurrCtr(solver, lambda_u=10e-3, Np=1)
+ctr = mpc.controllers.RLGridMpcCurrCtr(solver=solver, lambda_u=10e-3, Np=1)
 ctr_sys = common.ControlSystem(control_loops=[ref_ctr, ctr],
                                ref_seq=ref_seq,
                                Ts=100e-6)
 
 # Simulate the system
-sim = Simulation(sys=sys, conv=conv, ctr=ctr_sys, Ts_sim=5e-6)
+sim = Simulation(sys=sys, ctr=ctr_sys, Ts_sim=5e-6)
 sim.simulate(t_stop=0.2)
 sim.save_data()

--- a/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
+++ b/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
@@ -45,10 +45,8 @@ lcl_params = model.grid.LCLFilterParameters(R_fc_SI=0.1,
                                             base=base)
 
 # Define system models
-sys = model.grid.RLGridLCLFilter(par_grid=grid_params,
-                                 par_lcl_filter=lcl_params,
-                                 base=base)
 conv = model.conv.Converter(v_dc_SI=650, nl=2, base=base)
+sys = model.grid.RLGridLCLFilter(grid_params, lcl_params, conv, base)
 
 # Formulate and solve the problem as a QP. Indirect MPC is used.
 solver = mpc.solvers.IndirectMpcQP()
@@ -61,6 +59,6 @@ ctr = mpc.controllers.LCLVcMpcCtr(solver=solver, lambda_u=1e-4, Np=4)
 ctrSys = common.ControlSystem(control_loops=[ctr], ref_seq=ref_seq, Ts=100e-6)
 
 # Simulate the system
-sim = Simulation(sys=sys, conv=conv, ctr=ctrSys, Ts_sim=5e-6)
+sim = Simulation(sys=sys, ctr=ctrSys, Ts_sim=5e-6)
 sim.simulate(t_stop=0.2)
 sim.save_data()

--- a/examples/grid/rl_grid_state_space_curr_ctr.py
+++ b/examples/grid/rl_grid_state_space_curr_ctr.py
@@ -36,8 +36,8 @@ grid_params = model.grid.RLGridParameters(Vg_SI=3300,
                                           base=base)
 
 # Define system models
-sys = model.grid.RLGrid(par=grid_params, base=base, ig_ref_init=ig_ref_dq(0))
 conv = model.conv.Converter(v_dc_SI=5529.2, nl=3, base=base)
+sys = model.grid.RLGrid(grid_params, conv, base, ig_ref_dq(0))
 
 # Define controller
 ctr = RLGridStateSpaceCurrCtr(sys=sys,
@@ -46,6 +46,6 @@ ctr = RLGridStateSpaceCurrCtr(sys=sys,
                               ig_ref_seq_dq=ig_ref_dq)
 
 # Simulate the system
-sim = Simulation(sys=sys, conv=conv, ctr=ctr, Ts_sim=5e-6)
+sim = Simulation(sys=sys, ctr=ctr, Ts_sim=5e-6)
 sim.simulate(t_stop=0.2)
 sim.save_data()

--- a/examples/machine/im_direct_mpc_curr_ctr.py
+++ b/examples/machine/im_direct_mpc_curr_ctr.py
@@ -48,12 +48,12 @@ im_params = model.machine.InductionMachineParameters(fs_SI=50,
                                                      base=base)
 
 # Define system models
+conv = model.conv.Converter(v_dc_SI=600, nl=3, base=base)
 sys = model.machine.InductionMachine(par=im_params,
+                                     conv=conv,
                                      base=base,
                                      psiS_mag_ref=1,
                                      T_ref_init=T_ref_seq(0))
-
-conv = model.conv.Converter(v_dc_SI=600, nl=3, base=base)
 
 # Define solver to be enumeration based
 solver = mpc.solvers.MpcEnum(conv=conv)
@@ -66,6 +66,6 @@ ctr = mpc.controllers.IMMpcCurrCtr(solver, lambda_u=10e-3, Np=1)
 ctr_sys = common.ControlSystem(control_loops=[ctr], ref_seq=ref_seq, Ts=100e-6)
 
 # Simulate system
-sim = Simulation(sys=sys, conv=conv, ctr=ctr_sys, Ts_sim=5e-6)
+sim = Simulation(sys=sys, ctr=ctr_sys, Ts_sim=5e-6)
 sim.simulate(t_stop=0.2)
 sim.save_data()

--- a/soft4pes/control/common/control_system.py
+++ b/soft4pes/control/common/control_system.py
@@ -46,7 +46,7 @@ class ControlSystem:
         for control_loop in self.control_loops:
             control_loop.set_sampling_interval(Ts)
 
-    def __call__(self, sys, conv, kTs):
+    def __call__(self, sys, kTs):
         """
         Execute the control system for a given discrete time step. The control system
         1. Gets the references for the current time step.
@@ -57,8 +57,6 @@ class ControlSystem:
         ----------
         sys : object
             System model.
-        conv : object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 
@@ -74,7 +72,7 @@ class ControlSystem:
         # Execute the control loops
         for control_loop in self.control_loops:
             control_loop.input = ctr_input
-            ctr_input = control_loop.execute(sys, conv, kTs)
+            ctr_input = control_loop.execute(sys, kTs)
             control_loop.save_data()
 
         self.save_data(kTs=kTs)

--- a/soft4pes/control/common/controller.py
+++ b/soft4pes/control/common/controller.py
@@ -45,7 +45,7 @@ class Controller(ABC):
         self.Ts = Ts
 
     @abstractmethod
-    def execute(self, sys, conv, kTs):
+    def execute(self, sys, kTs):
         """
         Execute the controller.
 
@@ -53,8 +53,6 @@ class Controller(ABC):
         ----------
         sys : object
             System model.
-        conv : object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 

--- a/soft4pes/control/lin/grid_curr_ref_gen.py
+++ b/soft4pes/control/lin/grid_curr_ref_gen.py
@@ -15,7 +15,7 @@ class GridCurrRefGen(Controller):
     Moreover, the positive grid current flows from the converter to the grid.
     """
 
-    def execute(self, sys, conv, kTs):
+    def execute(self, sys, kTs):
         """
         Generate the current reference.
 
@@ -23,8 +23,6 @@ class GridCurrRefGen(Controller):
         ----------
         sys : object
             System model.
-        conv : object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 

--- a/soft4pes/control/lin/lcl_conv_curr_ctr.py
+++ b/soft4pes/control/lin/lcl_conv_curr_ctr.py
@@ -87,7 +87,7 @@ class LCLConvCurrCtr(Controller):
                                         k_ii=k_ii,
                                         k_ti=k_ti)
 
-    def execute(self, sys, conv, kTs):
+    def execute(self, sys, kTs):
         """
         Execute the Current Controller (CC) and save the controller data.
 
@@ -95,8 +95,6 @@ class LCLConvCurrCtr(Controller):
         ----------
         sys : object
             System model.
-        conv : object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 
@@ -131,7 +129,7 @@ class LCLConvCurrCtr(Controller):
 
         # Limiting the converter voltage reference
         v_conv_ref_comp = magnitude_limiter(v_conv_ref_unlim_comp,
-                                            conv.v_dc / 2)
+                                            sys.conv.v_dc / 2)
         self.v_conv_kp1_comp = v_conv_ref_comp
 
         self.u_ii_comp += self.ctr_pars.k_ii * (
@@ -143,7 +141,7 @@ class LCLConvCurrCtr(Controller):
         uk_abc = self.u_km1_abc
         v_conv_ref_dq = np.array([v_conv_ref_comp.real, v_conv_ref_comp.imag])
         v_conv_ref = dq_2_alpha_beta(v_conv_ref_dq, theta)
-        self.u_km1_abc = get_modulating_signal(v_conv_ref, conv.v_dc)
+        self.u_km1_abc = get_modulating_signal(v_conv_ref, sys.conv.v_dc)
         self.output = SimpleNamespace(uk_abc=uk_abc)
 
         return self.output

--- a/soft4pes/control/lin/lcl_vc_ctr.py
+++ b/soft4pes/control/lin/lcl_vc_ctr.py
@@ -140,7 +140,7 @@ class LCLVcCtr(Controller):
                                         k_iu=k_iu,
                                         k_tu=k_tu)
 
-    def execute(self, sys, conv, kTs):
+    def execute(self, sys, kTs):
         """
         Execute the Voltage Controller (VC) and save the controller data.
 
@@ -148,8 +148,6 @@ class LCLVcCtr(Controller):
         ----------
         sys : object
             System model.
-        conv : object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 

--- a/soft4pes/control/lin/rfpsc.py
+++ b/soft4pes/control/lin/rfpsc.py
@@ -59,7 +59,7 @@ class RFPSC(Controller):
             Vg = np.sqrt(2 / 3) * sys.par.Vg
             self.Kp = sys.par.wg * self.Ra / Vg
 
-    def execute(self, sys, conv, kTs):
+    def execute(self, sys, kTs):
         """
         Execute the RFPSC control algorithm.
 
@@ -67,8 +67,6 @@ class RFPSC(Controller):
         ----------
         sys : system object
             The system model.
-        conv : converter object
-            The converter model.
         kTs : float
             Current discrete time instant [s].
 
@@ -108,7 +106,7 @@ class RFPSC(Controller):
         v_ref_dq = alpha_beta_2_dq(v_ref, theta)
 
         self.output = SimpleNamespace(
-            uk_abc=get_modulating_signal(v_ref, conv.v_dc),
+            uk_abc=get_modulating_signal(v_ref, sys.conv.v_dc),
             vc_ref_dq=v_ref_dq,
         )
 

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -60,7 +60,7 @@ class RLGridStateSpaceCurrCtr:
             't': [],
         }
 
-    def __call__(self, sys, conv, kTs):
+    def __call__(self, sys, kTs):
         """
         Perform control.
 
@@ -68,8 +68,6 @@ class RLGridStateSpaceCurrCtr:
         ----------
         sys : system object
             System model.
-        conv : converter object
-            Converter model.
         kTs : float
             Current discrete time instant [s].
 
@@ -91,7 +89,7 @@ class RLGridStateSpaceCurrCtr:
         ic_dq = alpha_beta_2_dq(sys.x, theta)
 
         # Maximum converter output voltage
-        u_max = conv.v_dc / 2
+        u_max = sys.conv.v_dc / 2
 
         # As the filter is not concidered, the filter capacitor voltage is assumed to be the same
         # as the grid voltage after the grid indutance.
@@ -103,7 +101,7 @@ class RLGridStateSpaceCurrCtr:
         # Transform the converter voltage reference back to abc frame
         uc_abc = dq_2_abc(uc_dq, theta)
 
-        uk_abc = uc_abc / (conv.v_dc / 2)
+        uk_abc = uc_abc / (sys.conv.v_dc / 2)
 
         # Save controller data
         ig_ref = dq_2_alpha_beta(ic_ref_dq, theta)

--- a/soft4pes/control/mpc/solvers/mpc_QP.py
+++ b/soft4pes/control/mpc/solvers/mpc_QP.py
@@ -31,7 +31,7 @@ class IndirectMpcQP:
     def __init__(self):
         self.QP_matrices = None
 
-    def __call__(self, sys, conv, ctr, y_ref):
+    def __call__(self, sys, ctr, y_ref):
         """
         Formulate and solve the MPC QP.
 
@@ -39,8 +39,6 @@ class IndirectMpcQP:
         ----------
         sys : system object
             System model.
-        conv : converter object
-            Converter model.
         ctr : controller object
             Controller object.
         y_ref : ndarray of floats
@@ -53,7 +51,7 @@ class IndirectMpcQP:
         """
 
         if self.QP_matrices is None:
-            self.QP_matrices = make_QP_matrices(sys, conv, ctr)
+            self.QP_matrices = make_QP_matrices(sys, ctr)
 
         m = self.QP_matrices
 

--- a/soft4pes/control/mpc/solvers/mpc_enum.py
+++ b/soft4pes/control/mpc/solvers/mpc_enum.py
@@ -30,7 +30,7 @@ class MpcEnum:
         elif conv.nl == 3:
             self.sw_pos_3ph = np.array([-1, 0, 1])
 
-    def __call__(self, sys, conv, ctr, y_ref):
+    def __call__(self, sys, ctr, y_ref):
         """
         Solve MPC problem with exhaustive enumeration.
 
@@ -38,8 +38,6 @@ class MpcEnum:
         ----------
         sys : system object
             System model.
-        conv : converter object
-            Converter model.
         ctr : controller object
             Controller object.
         y_ref : ndarray of floats
@@ -56,14 +54,14 @@ class MpcEnum:
             self.U_seq = np.array(
                 list(product(self.sw_pos_3ph, repeat=3 * ctr.Np)))
 
-        J = self.solve(sys, conv, ctr, sys.x, y_ref, ctr.u_km1_abc)
+        J = self.solve(sys, ctr, sys.x, y_ref, ctr.u_km1_abc)
 
         # Find the switching sequences with the lowest cost
         min_index = np.argmin(J)
         uk_abc = self.U_seq[min_index, 0:3]
         return uk_abc
 
-    def solve(self, sys, conv, ctr, xk, y_ref, u_km1_abc):
+    def solve(self, sys, ctr, xk, y_ref, u_km1_abc):
         """
         Recursively compute the cost for different switching sequences
 
@@ -71,8 +69,6 @@ class MpcEnum:
         ----------
         sys : system object
             System model.
-        conv : converter object.
-            Converter model.
         ctr : controller object.
             Controller object.
         xk : ndarray of floats
@@ -90,7 +86,7 @@ class MpcEnum:
         """
 
         # Initialize the cost array
-        J = np.zeros((conv.nl**(3 * ctr.Np), 1))
+        J = np.zeros((sys.conv.nl**(3 * ctr.Np), 1))
 
         # Iterate over all possible switching sequences and three-phase switch positionss
         for i, u_seq in enumerate(self.U_seq):
@@ -107,7 +103,8 @@ class MpcEnum:
 
                 # Check if switching constraint is violated or the cost is already infinite
                 if switching_constraint_violated(
-                        conv.nl, u_ell_abc, u_ell_abc_prev) or J[i] == np.inf:
+                        sys.conv.nl, u_ell_abc,
+                        u_ell_abc_prev) or J[i] == np.inf:
                     # Set the cost to infinity and the next state to infinity
                     J[i] = np.inf
                     x_ell_next = np.full_like(x_ell, np.inf)

--- a/soft4pes/control/mpc/solvers/utils.py
+++ b/soft4pes/control/mpc/solvers/utils.py
@@ -33,7 +33,7 @@ def switching_constraint_violated(nl, uk_abc, u_km1_abc):
     return res
 
 
-def make_QP_matrices(sys, conv, ctr):
+def make_QP_matrices(sys, ctr):
     """
     Create the QP matrices.
 
@@ -41,8 +41,6 @@ def make_QP_matrices(sys, conv, ctr):
     ----------
     sys : system object
         System model.
-    conv : converter object
-        Converter model.
     ctr : controller object
         Controller object.
 
@@ -52,7 +50,7 @@ def make_QP_matrices(sys, conv, ctr):
         Namespace containing the QP matrices.
     """
 
-    model = sys.get_discrete_state_space(conv.v_dc, ctr.Ts)
+    model = ctr.state_space
     A_QP = model.A
     C = ctr.C
 

--- a/soft4pes/model/common/system_model.py
+++ b/soft4pes/model/common/system_model.py
@@ -3,12 +3,23 @@ System base class
 """
 from abc import ABC, abstractmethod
 from types import SimpleNamespace
+import numpy as np
+from scipy.linalg import expm
 
 
 class SystemModel(ABC):
     """
     System base class. The class implements some functionalities that are common for all system 
     models.
+
+    Parameters
+    ----------
+    par : system parameters
+        System parameters in p.u..
+    base : base value object
+        Base values.
+    conv : converter object
+        Converter object.
 
     Attributes
     ----------
@@ -18,33 +29,83 @@ class SystemModel(ABC):
         Namespace for storing simulation data.
     par : system parameters
         System parameters in p.u..
+    conv : converter object
+        Converter object.
     x : ndarray
         Current state of the system.
+    cont_state_space : SimpleNamespace
+        The continuous-time state-space model of the system.
     """
 
-    def __init__(self, par, base):
+    def __init__(self, par, base, conv):
         self.base = base
         self.data = SimpleNamespace(x=[], t=[], uk_abc=[])
         self.par = par
-        self.x = 0
+        self.conv = conv
+        if not hasattr(self, 'x'):
+            self.x = 0
+        self.cont_state_space = self.get_continuous_state_space()
 
     @abstractmethod
-    def get_discrete_state_space(self, v_dc, Ts):
+    def get_continuous_state_space(self):
         """
-        Calculates the discrete-time state-space model of the system.
-
-        Parameters
-        ----------
-        v_dc : float
-            The converter dc-link voltage [p.u.].
-        Ts : float
-            Sampling interval [s].
+        Calculates the continuous-time state-space model of the system.
 
         Returns
         -------
         SimpleNamespace
-            The discrete-time state-space model of the system.
+            The continuous-time state-space model of the system.
         """
+
+    def get_discrete_state_space(self, Ts, method):
+        """
+        Get the discrete-time state-space model using the specified discretization method.
+
+        Parameters
+        ----------
+        Ts : float
+            Sampling interval [s].
+        method : str, optional
+            Discretization method. Available options are 'forward_euler' or 'exact_discretization'.
+
+        Returns
+        -------
+        SimpleNamespace
+            Discrete-time state-space model.
+        """
+
+        cont_state_space = self.cont_state_space
+        Ts_pu = Ts * self.base.w
+        F_size = cont_state_space.F.shape[0]
+
+        # Discretize the state-space model using the specified method
+        # The continuous state-space model is dx/dt = Fx + Gu or dx/dt = Fx + G1u + G2d + ...
+        # Extract the matrices F, G, G1, G2, ... from the continuous state-space model, discretize
+        # them and store them in a SimpleNamespace object. Rename the matrices to A, B, B1, B2, ...,
+        # forming a discrete state-space model x[k+1] = Ax[k] + Bu[k] or
+        # x[k+1] = Ax[k] + B1u[k] + B2d[k] + ...
+        if method == 'forward_euler':
+            A = np.eye(F_size) + cont_state_space.F * Ts_pu
+            B = {
+                'B' + key[1:]: value * Ts_pu
+                for key, value in cont_state_space.__dict__.items()
+                if key.startswith('G')
+            }
+        elif method == 'exact_discretization':
+            A = expm(cont_state_space.F * Ts_pu)
+            B = {
+                'B' + key[1:]:
+                np.dot(-np.linalg.inv(cont_state_space.F),
+                       (np.eye(cont_state_space.F.shape[0]) - A)).dot(value)
+                for key, value in cont_state_space.__dict__.items()
+                if key.startswith('G')
+            }
+        else:
+            raise ValueError(
+                'Invalid discretization method. Available methods: forward_euler, '
+                'exact_discretization')
+
+        return SimpleNamespace(A=A, **B)
 
     @abstractmethod
     def set_initial_state(self, **kwargs):

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -19,7 +19,7 @@ class RLGrid(SystemModel):
     Parameters
     ----------
     par : RLGridParameters
-        Grid parameters in p.u..
+        Grid parameters in p.u.
     conv : converter object
         Converter object.
     base : base value object
@@ -32,7 +32,7 @@ class RLGrid(SystemModel):
     data : SimpleNamespace
         Namespace for storing simulation data.
     par : RLGridParameters
-        Grid parameters in p.u..
+        Grid parameters in p.u.
     conv : converter object
         Converter object.
     x : 1 x 2 ndarray of floats

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -20,6 +20,8 @@ class RLGrid(SystemModel):
     ----------
     par : RLGridParameters
         Grid parameters in p.u..
+    conv : converter object
+        Converter object.
     base : base value object
         Base values.
     ig_ref_init : 1 x 2 ndarray of floats, optional
@@ -27,16 +29,22 @@ class RLGrid(SystemModel):
 
     Attributes
     ----------
+    data : SimpleNamespace
+        Namespace for storing simulation data.
     par : RLGridParameters
         Grid parameters in p.u..
+    conv : converter object
+        Converter object.
     x : 1 x 2 ndarray of floats
         Current state of the grid [p.u.].
     base : base value object
         Base values.
+    cont_state_space : SimpleNamespace
+        The continuous-time state-space model of the system.
     """
 
-    def __init__(self, par, base, ig_ref_init=None):
-        super().__init__(par=par, base=base)
+    def __init__(self, par, conv, base, ig_ref_init=None):
+        super().__init__(par=par, base=base, conv=conv)
         self.set_initial_state(ig_ref_init=ig_ref_init)
 
     def set_initial_state(self, **kwargs):
@@ -57,40 +65,29 @@ class RLGrid(SystemModel):
         else:
             self.x = np.zeros(2)
 
-    def get_discrete_state_space(self, v_dc, Ts):
+    def get_continuous_state_space(self):
         """
-        Calculate the discrete-time state-space model of the system.
-
-        Parameters
-        ----------
-        v_dc : float
-            The converter dc-link voltage [p.u.].
-        Ts : float
-            Sampling interval [s].
+        Calculate the continuous-time state-space model of the system.
 
         Returns
         -------
         SimpleNamespace
-            The discrete-time state-space model of the system.
+            A SimpleNamespace object containing matrices F, G1 and G2 of the continuous-time 
+            state-space model. 
         """
 
         Rg = self.par.Rg
         Xg = self.par.Xg
-        Ts = Ts * self.base.w
 
         # Clarke transformation matrix
         K = (2 / 3) * np.array([[1, -1 / 2, -1 / 2],
                                 [0, np.sqrt(3) / 2, -np.sqrt(3) / 2]])
 
         F = -Rg / Xg * np.eye(2)
-        G1 = v_dc / 2 * 1 / Xg * K
+        G1 = self.conv.v_dc / 2 * 1 / Xg * K
         G2 = -1 / Xg * np.eye(2)
 
-        A = np.eye(2) + F * Ts
-        B1 = G1 * Ts
-        B2 = G2 * Ts
-
-        return SimpleNamespace(A=A, B1=B1, B2=B2)
+        return SimpleNamespace(F=F, G1=G1, G2=G2)
 
     def get_grid_voltage(self, kTs):
         """

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -19,7 +19,7 @@ class InductionMachine(SystemModel):
     Parameters
     ----------
     par : InductionMachineParameters
-        Induction machine parameters in p.u..
+        Induction machine parameters in p.u.
     conv : converter object
         Converter object.
     base : base value object
@@ -34,7 +34,7 @@ class InductionMachine(SystemModel):
     data : SimpleNamespace
         Namespace for storing simulation data.
     par : InductionMachineParameters
-        Induction machine parameters in p.u..
+        Induction machine parameters in p.u.
     conv : converter object
         Converter object.
     base : base value object

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -20,6 +20,8 @@ class InductionMachine(SystemModel):
     ----------
     par : InductionMachineParameters
         Induction machine parameters in p.u..
+    conv : converter object
+        Converter object.
     base : base value object
         Base values.
     psiS_mag_ref : float
@@ -29,20 +31,29 @@ class InductionMachine(SystemModel):
 
     Attributes
     ----------
+    data : SimpleNamespace
+        Namespace for storing simulation data.
     par : InductionMachineParameters
         Induction machine parameters in p.u..
+    conv : converter object
+        Converter object.
     base : base value object
         Base values.
     x : 1 x 4 ndarray of floats
         Current state of the machine [p.u.].
     psiR_mag_ref : float
         Rotor flux magnitude reference [p.u.].
+    wr : float
+        Electrical angular rotor speed [p.u.].
+    cont_state_space : SimpleNamespace
+        The continuous-time state-space model of the system.
     """
 
-    def __init__(self, par, base, psiS_mag_ref, T_ref_init):
-        super().__init__(par=par, base=base)
+    def __init__(self, par, conv, base, psiS_mag_ref, T_ref_init):
+        self.par = par
         self.set_initial_state(psiS_mag_ref=psiS_mag_ref,
                                T_ref_init=T_ref_init)
+        super().__init__(par=par, conv=conv, base=base)
         self.psiR_mag_ref = np.linalg.norm(self.x[2:4])
 
     def set_initial_state(self, **kwargs):
@@ -142,7 +153,17 @@ class InductionMachine(SystemModel):
         iS_q = T_ref / psiR_mag * self.par.Xr / self.par.Xm / self.par.kT
         return np.array([iS_d, iS_q])
 
-    def get_discrete_state_space(self, v_dc, Ts):
+    def get_continuous_state_space(self):
+        """
+        Calculate the continuous-time state-space model of the system.
+
+        Returns
+        -------
+        SimpleNamespace
+            A SimpleNamespace object containing matrices F and G of the continuous-time state-space 
+            model.
+        """
+
         wr = self.wr
         Rs = self.par.Rs
         Rr = self.par.Rr
@@ -152,8 +173,6 @@ class InductionMachine(SystemModel):
         tauS = Xr * D / (Rs * Xr**2 + Rr * Xm**2)
         tauR = Xr / Rr
 
-        Ts_pu = Ts * self.base.w
-
         K = (2 / 3) * np.array([[1, -1 / 2, -1 / 2],
                                 [0, np.sqrt(3) / 2, -np.sqrt(3) / 2]])
 
@@ -162,12 +181,10 @@ class InductionMachine(SystemModel):
                       [Xm / tauR, 0, -1 / tauR, -wr],
                       [0, Xm / tauR, wr, -1 / tauR]])
 
-        G = Xr / D * np.dot(np.array([[1, 0], [0, 1], [0, 0], [0, 0]]),
-                            K) * v_dc / 2
+        G = Xr / D * np.dot(np.block([[np.eye(2), np.zeros(
+            (2, 2))]]).T, K) * self.conv.v_dc / 2
 
-        A = np.eye(4) + F * Ts_pu
-        B = G * Ts_pu
-        return SimpleNamespace(A=A, B=B)
+        return SimpleNamespace(F=F, G=G)
 
     @property
     def Te(self):

--- a/soft4pes/sim/simulation.py
+++ b/soft4pes/sim/simulation.py
@@ -53,8 +53,6 @@ class Simulation:
     ----------
     sys : system object
         System model.
-    conv : converter object
-        Converter model.
     ctr : controller object
         Control system.
     Ts_sim : float
@@ -64,8 +62,6 @@ class Simulation:
     ----------
     sys : system object
         System model.
-    conv : converter object
-        Converter model.
     ctr : controller object.
         Control system.
     Ts_sim : float
@@ -78,14 +74,13 @@ class Simulation:
         Data from the simulation.
     """
 
-    def __init__(self, sys, conv, ctr, Ts_sim):
+    def __init__(self, sys, ctr, Ts_sim, disc_method='forward_euler'):
         self.sys = sys
-        self.conv = conv
         self.ctr = ctr
         self.Ts_sim = Ts_sim
         self.t_stop = 0
         self.matrices = self.sys.get_discrete_state_space(
-            self.conv.v_dc, self.Ts_sim)
+            self.Ts_sim, disc_method)
         self.simulation_data = None
 
         # Check if self.ctr.Ts/Ts_sim is an integer. Use tolerance to prevent
@@ -113,7 +108,7 @@ class Simulation:
 
             # Execute the controller
             kTs = k * self.ctr.Ts
-            uk_abc = self.ctr(self.sys, self.conv, kTs)
+            uk_abc = self.ctr(self.sys, kTs)
 
             for k_sim in range(int(self.ctr.Ts / self.Ts_sim)):
 


### PR DESCRIPTION
- This PR implements the option for choosing the discretization method for the simulation and control model. The chosen method does not have to be the same. 
- To simplify the structure and reduce the number of function/method parameters, the converter object has been include to the SystemModel base class. This change caused changes in several files, but fortunately the changes are simple. 
- Finally, the system model is saved to the controller during the first iteration

Please put you main focus to the choosing/implementation of the discretization methods

closes #84 