### PR TITLE
Remove the time instant from switch pos./mod. signal

### DIFF
--- a/soft4pes/control/common/control_system.py
+++ b/soft4pes/control/common/control_system.py
@@ -62,7 +62,7 @@ class ControlSystem:
 
         Returns
         -------
-        uk_abc : ndarray
+        u_abc : ndarray
             Three-phase switch position or modulating signal.
         """
 
@@ -80,10 +80,10 @@ class ControlSystem:
         # Form the three-phase switch position if PWM is used, otherwise use the output of the inner
         # (i.e., last) loop as a feedforward signal
         if self.pwm is not None:
-            uk_abc = self.pwm(ctr_input)
+            u_abc = self.pwm(ctr_input)
         else:
-            uk_abc = ctr_input.uk_abc
-        return uk_abc
+            u_abc = ctr_input.u_abc
+        return u_abc
 
     def get_references(self, kTs):
         """

--- a/soft4pes/control/lin/lcl_conv_curr_ctr.py
+++ b/soft4pes/control/lin/lcl_conv_curr_ctr.py
@@ -138,10 +138,10 @@ class LCLConvCurrCtr(Controller):
 
         # Get the modulating signal and Hold it for one cycle before sending it out from the
         # controller
-        uk_abc = self.u_km1_abc
+        u_abc = self.u_km1_abc
         v_conv_ref_dq = np.array([v_conv_ref_comp.real, v_conv_ref_comp.imag])
         v_conv_ref = dq_2_alpha_beta(v_conv_ref_dq, theta)
         self.u_km1_abc = get_modulating_signal(v_conv_ref, sys.conv.v_dc)
-        self.output = SimpleNamespace(uk_abc=uk_abc)
+        self.output = SimpleNamespace(u_abc=u_abc)
 
         return self.output

--- a/soft4pes/control/lin/rfpsc.py
+++ b/soft4pes/control/lin/rfpsc.py
@@ -73,7 +73,7 @@ class RFPSC(Controller):
         Returns
         -------
         SimpleNamespace
-            A SimpleNamespace object containing the modulating signal for the converter (uk_abc) and
+            A SimpleNamespace object containing the modulating signal for the converter (u_abc) and
             a capacitor voltage reference in case LC(L) filter is used (vc_ref).
         """
 
@@ -106,7 +106,7 @@ class RFPSC(Controller):
         v_ref_dq = alpha_beta_2_dq(v_ref, theta)
 
         self.output = SimpleNamespace(
-            uk_abc=get_modulating_signal(v_ref, sys.conv.v_dc),
+            u_abc=get_modulating_signal(v_ref, sys.conv.v_dc),
             vc_ref_dq=v_ref_dq,
         )
 

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -101,13 +101,13 @@ class RLGridStateSpaceCurrCtr:
         # Transform the converter voltage reference back to abc frame
         uc_abc = dq_2_abc(uc_dq, theta)
 
-        uk_abc = uc_abc / (sys.conv.v_dc / 2)
+        u_abc = uc_abc / (sys.conv.v_dc / 2)
 
         # Save controller data
         ig_ref = dq_2_alpha_beta(ic_ref_dq, theta)
-        self.save_data(ig_ref, uk_abc, kTs)
+        self.save_data(ig_ref, u_abc, kTs)
 
-        return uk_abc
+        return u_abc
 
     def get_state_space_ctr_pars(self):
         """
@@ -217,7 +217,7 @@ class RLGridStateSpaceCurrCtr:
 
         return uc_ref_dq
 
-    def save_data(self, ig_ref, uk_abc, kTs):
+    def save_data(self, ig_ref, u_abc, kTs):
         """
         Save controller data.
 
@@ -225,13 +225,13 @@ class RLGridStateSpaceCurrCtr:
         ----------
         ig_ref : 1 x 2 ndarray of floats
             Current reference in alpha-beta frame.
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         kTs : float
             Current discrete time instant [s].
         """
         self.data['ig_ref'].append(ig_ref)
-        self.data['u'].append(uk_abc)
+        self.data['u'].append(u_abc)
         self.data['t'].append(kTs)
 
     def get_control_system_data(self):

--- a/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
@@ -98,14 +98,14 @@ class IMMpcCurrCtr(Controller):
             y_ref[ell + 1, :] = np.dot(R_ref, y_ref[ell, :])
 
         # Solve the control problem
-        uk_abc = self.solver(sys, self, y_ref)
-        self.u_km1_abc = uk_abc
+        u_abc = self.solver(sys, self, y_ref)
+        self.u_km1_abc = u_abc
 
-        self.output = SimpleNamespace(uk_abc=uk_abc)
+        self.output = SimpleNamespace(u_abc=u_abc)
 
         return self.output
 
-    def get_next_state(self, sys, xk, uk_abc, k):
+    def get_next_state(self, sys, xk, u_abc, k):
         """
         Get the next state of the system.
 
@@ -115,7 +115,7 @@ class IMMpcCurrCtr(Controller):
             The system model.
         xk : 1 x 4 ndarray of floats
             The current state of the system.
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         k : int
             The solver prediction step.
@@ -127,4 +127,4 @@ class IMMpcCurrCtr(Controller):
         """
 
         return np.dot(self.state_space.A, xk) + np.dot(self.state_space.B,
-                                                       uk_abc)
+                                                       u_abc)

--- a/soft4pes/control/mpc/controllers/lcl_vc_mpc_ctr.py
+++ b/soft4pes/control/mpc/controllers/lcl_vc_mpc_ctr.py
@@ -131,14 +131,14 @@ class LCLVcMpcCtr(Controller):
             y_ref[ell + 1, :] = np.dot(R_rot, y_ref[ell, :])
 
         # Solve the control problem
-        uk_abc = self.solver(sys, self, y_ref)
-        self.u_km1_abc = uk_abc
+        u_abc = self.solver(sys, self, y_ref)
+        self.u_km1_abc = u_abc
 
-        self.output = SimpleNamespace(uk_abc=uk_abc)
+        self.output = SimpleNamespace(u_abc=u_abc)
 
         return self.output
 
-    def get_next_state(self, sys, xk, uk_abc, k):
+    def get_next_state(self, sys, xk, u_abc, k):
         """
         Get the next state of the system.
 
@@ -148,7 +148,7 @@ class LCLVcMpcCtr(Controller):
             The system model.
         xk : 1 x 6 ndarray of floats
             The current state of the system.
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         k : int
             The solver prediction step.
@@ -168,4 +168,4 @@ class LCLVcMpcCtr(Controller):
         vg_k = np.dot(R, self.vg)
 
         return np.dot(self.state_space.A, xk) + np.dot(
-            self.state_space.B1, uk_abc) + np.dot(self.state_space.B2, vg_k)
+            self.state_space.B1, u_abc) + np.dot(self.state_space.B2, vg_k)

--- a/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/rl_grid_mpc_curr_ctr.py
@@ -103,14 +103,14 @@ class RLGridMpcCurrCtr(Controller):
             y_ref[ell + 1, :] = np.dot(R_ref, y_ref[ell, :])
 
         # Solve the control problem
-        uk_abc = self.solver(sys, self, y_ref)
-        self.u_km1_abc = uk_abc
+        u_abc = self.solver(sys, self, y_ref)
+        self.u_km1_abc = u_abc
 
-        self.output = SimpleNamespace(uk_abc=uk_abc)
+        self.output = SimpleNamespace(u_abc=u_abc)
 
         return self.output
 
-    def get_next_state(self, sys, xk, uk_abc, k):
+    def get_next_state(self, sys, xk, u_abc, k):
         """
         Get the next state of the system.
 
@@ -120,7 +120,7 @@ class RLGridMpcCurrCtr(Controller):
             The system model.
         xk : 1 x 2 ndarray of floats
             The current state of the system.
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         k : int
             The solver prediction step.
@@ -140,4 +140,4 @@ class RLGridMpcCurrCtr(Controller):
         vg_k = np.dot(R, self.vg)
 
         return np.dot(self.state_space.A, xk) + np.dot(
-            self.state_space.B1, uk_abc) + np.dot(self.state_space.B2, vg_k)
+            self.state_space.B1, u_abc) + np.dot(self.state_space.B2, vg_k)

--- a/soft4pes/control/mpc/solvers/mpc_QP.py
+++ b/soft4pes/control/mpc/solvers/mpc_QP.py
@@ -46,7 +46,7 @@ class IndirectMpcQP:
 
         Returns
         -------
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             The three-phase modulating signal.
         """
 

--- a/soft4pes/control/mpc/solvers/mpc_bnb.py
+++ b/soft4pes/control/mpc/solvers/mpc_bnb.py
@@ -55,7 +55,7 @@ class MpcBnB:
 
         Returns
         -------
-        uk_abc : 1 x 3 ndarray of ints
+        u_abc : 1 x 3 ndarray of ints
             The three-phase switch position.
         """
 
@@ -65,8 +65,8 @@ class MpcBnB:
 
         self.solve(sys, ctr, sys.x, y_ref, ctr.u_km1_abc)
 
-        uk_abc = self.U_seq[0:3]
-        return uk_abc
+        u_abc = self.U_seq[0:3]
+        return u_abc
 
     def solve(self, sys, ctr, x_ell, y_ref, u_ell_abc_prev, ell=0, J_prev=0):
         """

--- a/soft4pes/control/mpc/solvers/mpc_enum.py
+++ b/soft4pes/control/mpc/solvers/mpc_enum.py
@@ -45,7 +45,7 @@ class MpcEnum:
 
         Returns
         -------
-        uk_abc : 1 x 3 ndarray of ints
+        u_abc : 1 x 3 ndarray of ints
             The three-phase switch position with the lowest cost.
         """
 
@@ -58,8 +58,8 @@ class MpcEnum:
 
         # Find the switching sequences with the lowest cost
         min_index = np.argmin(J)
-        uk_abc = self.U_seq[min_index, 0:3]
-        return uk_abc
+        u_abc = self.U_seq[min_index, 0:3]
+        return u_abc
 
     def solve(self, sys, ctr, xk, y_ref, u_km1_abc):
         """

--- a/soft4pes/control/mpc/solvers/utils.py
+++ b/soft4pes/control/mpc/solvers/utils.py
@@ -4,7 +4,7 @@ import numpy as np
 from types import SimpleNamespace
 
 
-def switching_constraint_violated(nl, uk_abc, u_km1_abc):
+def switching_constraint_violated(nl, u_abc, u_km1_abc):
     """
     Check if a candidate three-phase switch position violates a switching constraint. 
     A three-level converter is not allowed to directly switch from -1 and 1 (and vice versa) 
@@ -14,7 +14,7 @@ def switching_constraint_violated(nl, uk_abc, u_km1_abc):
     ----------
     nl : int
         Number of converter voltage levels.
-    uk_abc : 1 x 3 ndarray of ints
+    u_abc : 1 x 3 ndarray of ints
         three-phase switch position.
     u_km1_abc : 1 x 3 ndarray of ints
         Previously applied three-phase switch position.
@@ -28,7 +28,7 @@ def switching_constraint_violated(nl, uk_abc, u_km1_abc):
     if nl == 2:
         res = False
     elif nl == 3:
-        res = np.linalg.norm(uk_abc - u_km1_abc, np.inf) >= 2
+        res = np.linalg.norm(u_abc - u_km1_abc, np.inf) >= 2
 
     return res
 

--- a/soft4pes/model/common/system_model.py
+++ b/soft4pes/model/common/system_model.py
@@ -39,7 +39,7 @@ class SystemModel(ABC):
 
     def __init__(self, par, base, conv):
         self.base = base
-        self.data = SimpleNamespace(x=[], t=[], uk_abc=[])
+        self.data = SimpleNamespace(x=[], t=[], u_abc=[])
         self.par = par
         self.conv = conv
         if not hasattr(self, 'x'):
@@ -119,13 +119,13 @@ class SystemModel(ABC):
         """
 
     @abstractmethod
-    def get_next_state(self, matrices, uk_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs):
         """
         Calculate the next state of the system.
 
         Parameters
         ----------
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         matrices : SimpleNamespace
             A SimpleNamespace object containing the state-space model matrices.
@@ -147,7 +147,7 @@ class SystemModel(ABC):
             Current discrete time instant [s].
         """
 
-    def update(self, matrices, uk_abc, kTs):
+    def update(self, matrices, u_abc, kTs):
         """
         Update the system state and save data.
 
@@ -155,7 +155,7 @@ class SystemModel(ABC):
         ----------
         matrices : SimpleNamespace
             A SimpleNamespace object containing the state-space model matrices.
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         kTs : float
             Current discrete time instant [s].
@@ -164,10 +164,10 @@ class SystemModel(ABC):
         """
 
         meas = self.get_measurements(kTs)
-        self.save_data(kTs, uk_abc, meas)
-        self.x = self.get_next_state(matrices, uk_abc, kTs)
+        self.save_data(kTs, u_abc, meas)
+        self.x = self.get_next_state(matrices, u_abc, kTs)
 
-    def save_data(self, kTs, uk_abc, meas):
+    def save_data(self, kTs, u_abc, meas):
         """
         Save simulation data.
 
@@ -175,7 +175,7 @@ class SystemModel(ABC):
         ----------
         kTs : float
             Current discrete time instant [s].
-        uk_abc : 1 x 3 ndarray of floats 
+        u_abc : 1 x 3 ndarray of floats 
             Converter three-phase switch position or modulating signal.
         meas : SimpleNamespace, optional
             Measurement data.
@@ -183,7 +183,7 @@ class SystemModel(ABC):
 
         self.data.x.append(self.x)
         self.data.t.append(kTs)
-        self.data.uk_abc.append(uk_abc)
+        self.data.u_abc.append(u_abc)
         if meas is not None:
             for key, value in meas.__dict__.items():
                 if not hasattr(self.data, key):

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -114,13 +114,13 @@ class RLGrid(SystemModel):
         vg = abc_2_alpha_beta(vg_abc)
         return vg
 
-    def get_next_state(self, matrices, uk_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs):
         """
         Calculate the next state of the system.
 
         Parameters
         ----------
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         matrices : SimpleNamespace
             A SimpleNamespace object containing the state-space model matrices.
@@ -135,7 +135,7 @@ class RLGrid(SystemModel):
 
         vg = self.get_grid_voltage(kTs)
         x_kp1 = np.dot(matrices.A, self.x) + np.dot(
-            matrices.B1, uk_abc) + np.dot(matrices.B2, vg)
+            matrices.B1, u_abc) + np.dot(matrices.B2, vg)
         return x_kp1
 
     def get_measurements(self, kTs):

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -192,13 +192,13 @@ class InductionMachine(SystemModel):
         psiR = self.x[2:4]
         return self.par.kT * (self.par.Xm / self.par.Xr) * np.cross(psiR, iS)
 
-    def get_next_state(self, matrices, uk_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs):
         """
         Calculate the next state of the system.
 
         Parameters
         ----------
-        uk_abc : 1 x 3 ndarray of floats
+        u_abc : 1 x 3 ndarray of floats
             Converter three-phase switch position or modulating signal.
         matrices : SimpleNamespace
             A SimpleNamespace object containing the state-space model matrices.
@@ -211,7 +211,7 @@ class InductionMachine(SystemModel):
             The next state of the system.
         """
 
-        x_kp1 = np.dot(matrices.A, self.x) + np.dot(matrices.B, uk_abc)
+        x_kp1 = np.dot(matrices.A, self.x) + np.dot(matrices.B, u_abc)
         return x_kp1
 
     def get_measurements(self, kTs):

--- a/soft4pes/sim/simulation.py
+++ b/soft4pes/sim/simulation.py
@@ -108,12 +108,12 @@ class Simulation:
 
             # Execute the controller
             kTs = k * self.ctr.Ts
-            uk_abc = self.ctr(self.sys, kTs)
+            u_abc = self.ctr(self.sys, kTs)
 
             for k_sim in range(int(self.ctr.Ts / self.Ts_sim)):
 
                 kTs_sim = kTs + k_sim * self.Ts_sim
-                self.sys.update(self.matrices, uk_abc, kTs_sim)
+                self.sys.update(self.matrices, u_abc, kTs_sim)
 
             progress_printer(k)
 


### PR DESCRIPTION
three-phase switch position / modulating signal was named as `uk_abc`. As none of the other quantities specify the discrete time instant, this should not either, so it is now renamed as `u_abc`. In solvers the time instant is marked with `ell` if necessary.

closes #86 