### PR TITLE
Add second norm calculation

### DIFF
--- a/soft4pes/control/mpc/solvers/__init__.py
+++ b/soft4pes/control/mpc/solvers/__init__.py
@@ -8,6 +8,7 @@ from soft4pes.control.mpc.solvers.mpc_bnb import MpcBnB
 from soft4pes.control.mpc.solvers.mpc_enum import MpcEnum
 from soft4pes.control.mpc.solvers.utils import (
     switching_constraint_violated,
+    weighted_second_norm,
     make_QP_matrices,
     make_Gamma,
     make_Upsilon,
@@ -18,6 +19,7 @@ __all__ = [
     'MpcBnB',
     'MpcEnum',
     'switching_constraint_violated',
+    'weighted_second_norm',
     'make_QP_matrices',
     'make_Gamma',
     'make_Upsilon',

--- a/soft4pes/control/mpc/solvers/mpc_bnb.py
+++ b/soft4pes/control/mpc/solvers/mpc_bnb.py
@@ -2,7 +2,8 @@
 
 from itertools import product
 import numpy as np
-from soft4pes.control.mpc.solvers.utils import switching_constraint_violated
+from soft4pes.control.mpc.solvers.utils import (switching_constraint_violated,
+                                                weighted_second_norm)
 
 
 class MpcBnB:
@@ -33,9 +34,11 @@ class MpcBnB:
 
         if conv.nl == 2:
             sw_pos_3ph = np.array([-1, 1])
-
         elif conv.nl == 3:
             sw_pos_3ph = np.array([-1, 0, 1])
+        else:
+            raise ValueError(
+                'Only two- and three-level converters are supported.')
 
         # Create all possible three-phase switch positions
         self.SW_COMB = np.array(list(product(sw_pos_3ph, repeat=3)))
@@ -102,7 +105,9 @@ class MpcBnB:
 
                 # Calculate the cost of reference tracking and control effort
                 y_ell_next = np.dot(ctr.C, x_ell_next)
-                y_error = np.linalg.norm(y_ref[ell + 1] - y_ell_next)**2
+                Q = np.eye(np.size(y_ref[ell + 1]))
+                y_error = weighted_second_norm(y_ref[ell + 1] - y_ell_next,
+                                               Q)**2
                 delta_u = np.linalg.norm(u_ell_abc - u_ell_abc_prev, ord=1)
                 J_temp = J_prev + y_error + ctr.lambda_u * delta_u
 

--- a/soft4pes/control/mpc/solvers/utils.py
+++ b/soft4pes/control/mpc/solvers/utils.py
@@ -26,11 +26,32 @@ def switching_constraint_violated(nl, uk_abc, u_km1_abc):
     """
 
     if nl == 2:
-        res = False
+        return False
     elif nl == 3:
-        res = np.linalg.norm(uk_abc - u_km1_abc, np.inf) >= 2
+        return np.linalg.norm(uk_abc - u_km1_abc, np.inf) >= 2
+    else:
+        raise ValueError('Only two- and three-level converters are supported.')
 
-    return res
+
+def weighted_second_norm(vector, Q):
+    """
+    Compute the weighted second norm of a vector. The elements of the norm are weighted by the
+    weighting matrix Q.
+    
+    Parameters
+    ----------
+    vector : ndarray
+        Vector.
+    Q : ndarray
+        Weighting matrix.
+
+    Returns
+    -------
+    float
+        Weighted second norm.
+    """
+
+    return np.sqrt(np.dot(vector.T, Q).dot(vector))
 
 
 def make_QP_matrices(sys, ctr):


### PR DESCRIPTION
Add calculation for weighted second norm, i.e. ||vector||_Q,. This is used in the direct MPC solvers (BnB, enumeration). The weight matrix Q is now defined in the solvers to be just an identity matrix. This will be changed later, when MPC functionalities are reformulated. 

In addition, error handling added for converter level checking.

closes #88 