### PR TITLE
create Voltage sequence

### DIFF
--- a/soft4pes/control/lin/rfpsc.py
+++ b/soft4pes/control/lin/rfpsc.py
@@ -43,9 +43,10 @@ class RFPSC(Controller):
         First-order filter for the current.
     Kp : float
         Proportional gain of the active power droop control [p.u.]. Recommended selection is 
-        Kp = wg * Ra / Vg, where wg is the nominal grid frequency, Ra is the virtual damping
-        resistance (default 0.2) and Vg is the nominal grid peak voltage. If value is not provided, 
-        nominal grid frequency and nominal grid peak voltage are assumed to be 1 p.u.
+        Kp = wg * Ra / Vg, where wg is the nominal grid angular frequency, Ra is the virtual damping
+        resistance (default 0.2 p.u.) and Vg is the nominal grid peak voltage. If value is not 
+        provided, nominal grid angular frequency and nominal grid peak voltage are assumed to be 
+        1 p.u. For more details on the tuning and default values, see the reference above.
     """
 
     def __init__(self, sys, Ra=0.2, Kp=None, w_bw=0.1):

--- a/soft4pes/control/lin/rfpsc.py
+++ b/soft4pes/control/lin/rfpsc.py
@@ -42,7 +42,10 @@ class RFPSC(Controller):
     ig_filter : FirstOrderFilter
         First-order filter for the current.
     Kp : float
-        Proportional gain of the active power droop control [p.u.].
+        Proportional gain of the active power droop control [p.u.]. Recommended selection is 
+        Kp = wg * Ra / Vg, where wg is the nominal grid frequency, Ra is the virtual damping
+        resistance (default 0.2) and Vg is the nominal grid peak voltage. If value is not provided, 
+        nominal grid frequency and nominal grid peak voltage are assumed to be 1 p.u.
     """
 
     def __init__(self, sys, Ra=0.2, Kp=None, w_bw=0.1):
@@ -55,9 +58,11 @@ class RFPSC(Controller):
             self.Kp = Kp
         else:
             # If Kp is not provided, calculate it based on the nominal frequency, nominal grid peak
-            # voltage and the virtual damping resistance according to the reference
-            Vg = np.sqrt(2 / 3) * sys.par.Vg
-            self.Kp = sys.par.wg * self.Ra / Vg
+            # voltage and the virtual damping resistance according to the reference. Nominal grid
+            # frequency and nominal grid peak voltage are assumed to be 1 p.u.
+            Vg = 1
+            wg = 1
+            self.Kp = wg * self.Ra / Vg
 
     def execute(self, sys, kTs):
         """

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -106,8 +106,16 @@ class RLGrid(SystemModel):
 
         theta = self.par.wg * (kTs * self.base.w)
 
+        # Handle both constant and sequence-based Vg
+        if hasattr(self.par.Vg, '__call__'):
+            # If Vg is a Sequence, get its value at the current time step
+            Vg_value = self.par.Vg(kTs)
+        else:
+            # If Vg is a constant
+            Vg_value = self.par.Vg
+
         # Grid peak voltage
-        Vg = np.sqrt(2 / 3) * self.par.Vg
+        Vg = np.sqrt(2 / 3) * Vg_value
 
         vg_abc = Vg * np.sin(theta + 2 * np.pi / 3 * np.array([0, -1, 1]))
 

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -2,7 +2,7 @@
 
 from types import SimpleNamespace
 import numpy as np
-from soft4pes.utils import abc_2_alpha_beta
+from soft4pes.utils import Sequence, abc_2_alpha_beta
 from soft4pes.model.common.system_model import SystemModel
 from soft4pes.utils.conversions import dq_2_alpha_beta
 
@@ -107,15 +107,11 @@ class RLGrid(SystemModel):
         theta = self.par.wg * (kTs * self.base.w)
 
         # Handle both constant and sequence-based Vg
-        if hasattr(self.par.Vg, '__call__'):
-            # If Vg is a Sequence, get its value at the current time step
-            Vg_value = self.par.Vg(kTs)
+        if isinstance(self.par.Vg, Sequence):
+            # Grid peak voltage
+            Vg = np.sqrt(2 / 3) * self.par.Vg(kTs)
         else:
-            # If Vg is a constant
-            Vg_value = self.par.Vg
-
-        # Grid peak voltage
-        Vg = np.sqrt(2 / 3) * Vg_value
+            Vg = np.sqrt(2 / 3) * self.par.Vg
 
         vg_abc = Vg * np.sin(theta + 2 * np.pi / 3 * np.array([0, -1, 1]))
 

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -1,4 +1,5 @@
-""" Model of a grid with stiff voltage source and RL-load in alpha-beta frame"""
+""" Model of a grid with a voltage source and an RL-load in alpha-beta frame. The magnitude of the
+grid voltage is configurable as a function of time. """
 
 from types import SimpleNamespace
 import numpy as np
@@ -9,10 +10,10 @@ from soft4pes.utils.conversions import dq_2_alpha_beta
 
 class RLGrid(SystemModel):
     """
-    Model of a grid with stiff voltage source and RL-load in alpha-beta frame. The state of the 
-    system is the grid current in the alpha-beta frame. The system input is the converter 
-    three-phase switch position or modulating signal. The grid voltage is considered to be a 
-    disturbance.
+    Model of a grid with a voltage source and an RL-load in alpha-beta frame. The magnitude of the
+    grid voltage is configurable as a function of time using a Sequence object. The system input is 
+    the converter three-phase switch position or modulating signal. The grid voltage is considered 
+    to be a disturbance.
 
     This class can be used as a base class for other grid models.
 
@@ -106,9 +107,8 @@ class RLGrid(SystemModel):
 
         theta = self.par.wg * (kTs * self.base.w)
 
-        # Handle both constant and sequence-based Vg
+        # Get grid peak voltage
         if isinstance(self.par.Vg, Sequence):
-            # Grid peak voltage
             Vg = np.sqrt(2 / 3) * self.par.Vg(kTs)
         else:
             Vg = np.sqrt(2 / 3) * self.par.Vg

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -1,5 +1,5 @@
-""" Model of a grid with a voltage source and an RL-load in alpha-beta frame. The magnitude of the
-grid voltage is configurable as a function of time. """
+""" Model of a grid with a voltage source and an RL impedance in alpha-beta frame. The magnitude of 
+the grid voltage is configurable as a function of time. """
 
 from types import SimpleNamespace
 import numpy as np
@@ -10,10 +10,10 @@ from soft4pes.utils.conversions import dq_2_alpha_beta
 
 class RLGrid(SystemModel):
     """
-    Model of a grid with a voltage source and an RL-load in alpha-beta frame. The magnitude of the
-    grid voltage is configurable as a function of time using a Sequence object. The system input is 
-    the converter three-phase switch position or modulating signal. The grid voltage is considered 
-    to be a disturbance.
+    Model of a grid with a voltage source and an RL impedance in alpha-beta frame. The magnitude of 
+    the grid voltage is configurable as a function of time using a Sequence object. The system input
+    is the converter three-phase switch position or modulating signal. The grid voltage is 
+    considered to be a disturbance.
 
     This class can be used as a base class for other grid models.
 

--- a/soft4pes/model/grid/rl_grid_lcl_filter.py
+++ b/soft4pes/model/grid/rl_grid_lcl_filter.py
@@ -1,5 +1,5 @@
 """ 
-Model of a grid with stiff voltage source, RL-load and an LC(L) filter in alpha-beta frame.
+Model of a grid with stiff voltage source, RL impedance and an LC(L) filter in alpha-beta frame.
 """
 
 from types import SimpleNamespace
@@ -10,8 +10,8 @@ from soft4pes.model.grid.rl_grid import RLGrid
 
 class RLGridLCLFilter(RLGrid):
     """
-    Model of a grid with stiff voltage source, RL-load and an LC(L) filter in alpha-beta frame. If 
-    the grid side inductance is not provided, the filter is in LC configuration.
+    Model of a grid with stiff voltage source, RL impedance and an LC(L) filter in alpha-beta frame.
+    If the grid side inductance is not provided, the filter is in LC configuration.
     
     The state of the system is the converter current, the capacitor voltage and the grid current in 
     the alpha-beta frame, i.e. x = [i_conv^T, ig^T, vc^T]^T. The system input is the converter 

--- a/soft4pes/model/grid/rl_grid_param.py
+++ b/soft4pes/model/grid/rl_grid_param.py
@@ -3,6 +3,7 @@ Parameters for a grid with a stiff voltage source and RL-load.
 """
 
 import numpy as np
+from soft4pes.utils import Sequence
 
 
 class RLGridParameters:
@@ -35,7 +36,19 @@ class RLGridParameters:
     """
 
     def __init__(self, Vg_SI, fg_SI, Rg_SI, Lg_SI, base):
-        self.Vg = Vg_SI / base.V
+        if isinstance(Vg_SI, Sequence):
+            # If Vg_SI is a Sequence, convert its values to p.u.
+            self.Vg = Sequence(times=Vg_SI.times, values=Vg_SI.values / base.V)
+        else:
+            # If Vg_SI is a float, convert to p.u.
+            self.Vg = Vg_SI / base.V
+
         self.wg = 2 * np.pi * fg_SI / base.w
         self.Rg = Rg_SI / base.Z
         self.Xg = Lg_SI / base.L
+
+    def __call__(self, kTs):
+        # If Vg is a Sequence, get the value at the specific time step
+        if isinstance(self.Vg, Sequence):
+            return self.Vg(kTs)
+        return self.Vg

--- a/soft4pes/model/grid/rl_grid_param.py
+++ b/soft4pes/model/grid/rl_grid_param.py
@@ -46,9 +46,3 @@ class RLGridParameters:
         self.wg = 2 * np.pi * fg_SI / base.w
         self.Rg = Rg_SI / base.Z
         self.Xg = Lg_SI / base.L
-
-    def __call__(self, kTs):
-        # If Vg is a Sequence, get the value at the specific time step
-        if isinstance(self.Vg, Sequence):
-            return self.Vg(kTs)
-        return self.Vg

--- a/soft4pes/model/grid/rl_grid_param.py
+++ b/soft4pes/model/grid/rl_grid_param.py
@@ -1,5 +1,6 @@
 """
-Parameters for a grid with a stiff voltage source and RL-load.
+Parameters for a grid with a voltage source and an RL-load. The grid voltage can be given as a 
+constant or as a function of time using a Sequence object. 
 """
 
 import numpy as np
@@ -8,11 +9,12 @@ from soft4pes.utils import Sequence
 
 class RLGridParameters:
     """
-    Parameters for a grid with a stiff voltage source and RL-load.
+    Parameters for a grid with a voltage source and an RL-load. The grid voltage can be given as a 
+    constant or as a function of time using a Sequence object. 
 
     Parameters
     ----------
-    Vg_SI : float
+    Vg_SI : float or Sequence
         Grid voltage [V] (line-to-line rms voltage).
     fg_SI : float
         Grid frequency [Hz].
@@ -25,7 +27,7 @@ class RLGridParameters:
 
     Attributes
     ----------
-    Vg : float
+    Vg : float or Sequence
         Grid voltage [p.u.] (line-to-line rms voltage).
     wg : float
         Angular frequency [p.u.].
@@ -37,10 +39,8 @@ class RLGridParameters:
 
     def __init__(self, Vg_SI, fg_SI, Rg_SI, Lg_SI, base):
         if isinstance(Vg_SI, Sequence):
-            # If Vg_SI is a Sequence, convert its values to p.u.
             self.Vg = Sequence(times=Vg_SI.times, values=Vg_SI.values / base.V)
         else:
-            # If Vg_SI is a float, convert to p.u.
             self.Vg = Vg_SI / base.V
 
         self.wg = 2 * np.pi * fg_SI / base.w

--- a/soft4pes/model/grid/rl_grid_param.py
+++ b/soft4pes/model/grid/rl_grid_param.py
@@ -1,5 +1,5 @@
 """
-Parameters for a grid with a voltage source and an RL-load. The grid voltage can be given as a 
+Parameters for a grid with a voltage source and an RL impedance. The grid voltage can be given as a 
 constant or as a function of time using a Sequence object. 
 """
 
@@ -9,8 +9,8 @@ from soft4pes.utils import Sequence
 
 class RLGridParameters:
     """
-    Parameters for a grid with a voltage source and an RL-load. The grid voltage can be given as a 
-    constant or as a function of time using a Sequence object. 
+    Parameters for a grid with a voltage source and an RL impedance. The grid voltage can be given 
+    as a constant or as a function of time using a Sequence object. 
 
     Parameters
     ----------


### PR DESCRIPTION
Add a feature to the RLGridParameters class to retrieve grid voltage as a sequence. If it is a sequence, call a function to obtain the grid voltage at every sample time in the RLGrid function get_grid_voltage. Additionally, allow retrieving a single grid voltage value instead of a sequence.