### PR TITLE
Add state variable functionality

### DIFF
--- a/soft4pes/control/lin/lcl_conv_curr_ctr.py
+++ b/soft4pes/control/lin/lcl_conv_curr_ctr.py
@@ -113,10 +113,10 @@ class LCLConvCurrCtr(Controller):
         i_conv_ref_comp = complex(*self.input.i_conv_ref_dq)
 
         # Get the converter current in dq-frame
-        i_conv_comp = complex(*alpha_beta_2_dq(sys.x[:2], theta))
+        i_conv_comp = complex(*alpha_beta_2_dq(sys.i_conv, theta))
 
         # Get the capacitor voltage in dq-frame
-        vc_comp = complex(*alpha_beta_2_dq(sys.x[4:6], theta))
+        vc_comp = complex(*alpha_beta_2_dq(sys.vc, theta))
 
         # Get the converter voltage
         v_conv_comp = self.v_conv_kp1_comp * self.ctr_pars.delta

--- a/soft4pes/control/lin/lcl_vc_ctr.py
+++ b/soft4pes/control/lin/lcl_vc_ctr.py
@@ -166,10 +166,10 @@ class LCLVcCtr(Controller):
         vc_ref_comp = complex(*self.input.vc_ref_dq)
 
         # Get the converter current in dq-frame
-        i_conv_comp = complex(*alpha_beta_2_dq(sys.x[:2], theta))
+        i_conv_comp = complex(*alpha_beta_2_dq(sys.i_conv, theta))
 
         # Get the capacitor voltage in dq-frame
-        vc_comp = complex(*alpha_beta_2_dq(sys.x[4:6], theta))
+        vc_comp = complex(*alpha_beta_2_dq(sys.vc, theta))
 
         # Get the converter voltage
         v_conv_comp = self.curr_ctr.v_conv_kp1_comp * self.ctr_pars.delta

--- a/soft4pes/control/lin/rfpsc.py
+++ b/soft4pes/control/lin/rfpsc.py
@@ -81,13 +81,8 @@ class RFPSC(Controller):
         P_ref = self.input.P_ref
 
         vg = sys.get_grid_voltage(kTs)
-        if isinstance(sys, RLGridLCLFilter):
-            ig = sys.x[2:4]
-        else:
-            ig = sys.x
-
-        ig_dq = alpha_beta_2_dq(ig, self.theta_c)
-        P = np.dot(vg, ig)
+        ig_dq = alpha_beta_2_dq(sys.ig, self.theta_c)
+        P = np.dot(vg, sys.ig)
 
         # Droop control
         wc = sys.par.wg + self.Kp * (P_ref - P)

--- a/soft4pes/control/lin/state_space_curr_ctr.py
+++ b/soft4pes/control/lin/state_space_curr_ctr.py
@@ -86,7 +86,7 @@ class RLGridStateSpaceCurrCtr:
         theta = np.arctan2(vg[1], vg[0])
 
         # Get dq frame current (converter current equals grid current due to lack of a filter)
-        ic_dq = alpha_beta_2_dq(sys.x, theta)
+        ic_dq = alpha_beta_2_dq(sys.i_conv, theta)
 
         # Maximum converter output voltage
         u_max = sys.conv.v_dc / 2

--- a/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/im_mpc_curr_ctr.py
@@ -80,7 +80,7 @@ class IMMpcCurrCtr(Controller):
         iS_ref_dq = sys.calc_stator_current(sys.psiR_mag_ref, T_ref)
 
         # Get the rotor flux angle and calculate the reference in alpha-beta frame
-        theta = np.arctan2(sys.x[3], sys.x[2])
+        theta = np.arctan2(sys.psiR[1], sys.psiR[0])
         iS_ref = dq_2_alpha_beta(iS_ref_dq, theta)
         self.input.iS_ref = iS_ref
 

--- a/soft4pes/control/mpc/solvers/utils.py
+++ b/soft4pes/control/mpc/solvers/utils.py
@@ -28,7 +28,7 @@ def switching_constraint_violated(nl, u_abc, u_km1_abc):
     if nl == 2:
         return False
     elif nl == 3:
-        return np.linalg.norm(uk_abc - u_km1_abc, np.inf) >= 2
+        return np.linalg.norm(u_abc - u_km1_abc, np.inf) >= 2
     else:
         raise ValueError('Only two- and three-level converters are supported.')
 

--- a/soft4pes/model/common/system_model.py
+++ b/soft4pes/model/common/system_model.py
@@ -34,7 +34,7 @@ class SystemModel(ABC):
     x : ndarray
         Current state of the system.
     state_map : dict
-        A dictionary mapping state names to slices of the state vector.
+        A dictionary mapping states to elements of the state vector.
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
     """
@@ -54,7 +54,7 @@ class SystemModel(ABC):
         x_size : int
             Length of the state vector.
         state_map : dict
-            A dictionary mapping state names to slices of the state vector.
+            A dictionary mapping states to elements of the state vector.
         """
         self.base = base
         self.data = SimpleNamespace(x=[], t=[], u_abc=[])
@@ -67,7 +67,7 @@ class SystemModel(ABC):
 
     def __getattr__(self, name):
         """
-        Dynamically retrieve slices of the state vector based on the state map.
+        Dynamically retrieve elements of the state vector based on the state map.
 
         Parameters
         ----------

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -42,7 +42,7 @@ class RLGrid(SystemModel):
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
     state_map : dict
-        A dictionary mapping state names to slices of the state vector.
+        A dictionary mapping states to elements of the state vector.
     """
 
     def __init__(self, par, conv, base, ig_ref_init=None):

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -10,9 +10,9 @@ from soft4pes.utils.conversions import dq_2_alpha_beta
 class RLGrid(SystemModel):
     """
     Model of a grid with stiff voltage source and RL-load in alpha-beta frame. The state of the 
-    system is the grid current in the alpha-beta frame. The system input is the converter 
-    three-phase switch position or modulating signal. The grid voltage is considered to be a 
-    disturbance.
+    system is the grid current (same as the converter current) in the alpha-beta frame. The system 
+    input is the converter three-phase switch position or modulating signal. The grid voltage is 
+    considered to be a disturbance.
 
     This class can be used as a base class for other grid models.
 
@@ -41,10 +41,19 @@ class RLGrid(SystemModel):
         Base values.
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
+    state_map : dict
+        A dictionary mapping state names to slices of the state vector.
     """
 
     def __init__(self, par, conv, base, ig_ref_init=None):
-        super().__init__(par=par, base=base, conv=conv)
+        super().__init__(par=par,
+                         base=base,
+                         conv=conv,
+                         x_size=2,
+                         state_map={
+                             'ig': slice(0, 2),
+                             'i_conv': slice(0, 2)
+                         })
         self.set_initial_state(ig_ref_init=ig_ref_init)
 
     def set_initial_state(self, **kwargs):

--- a/soft4pes/model/grid/rl_grid_lcl_filter.py
+++ b/soft4pes/model/grid/rl_grid_lcl_filter.py
@@ -45,11 +45,21 @@ class RLGridLCLFilter(RLGrid):
         Base values.
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
+    state_map : dict
+        A dictionary mapping state names to slices of the state vector.
     """
 
     def __init__(self, par_grid, par_lcl_filter, conv, base):
         par = SimpleNamespace(**vars(par_grid), **vars(par_lcl_filter))
-        super().__init__(par, conv, base)
+        super().__init__(par=par, conv=conv, base=base)
+        state_map = {
+            'i_conv': slice(0, 2),  # Converter current (x[0:2])
+            'ig': slice(2, 4),  # Grid current (x[2:4])
+            'vc': slice(4, 6),  # Capacitor voltage (x[4:6])
+        }
+        # Overwrite the state map of RLGrid with the one of RLGridLCLFilter
+        self.x_size = 6
+        self.state_map = state_map
         self.set_initial_state()
 
     def set_initial_state(self, **kwargs):

--- a/soft4pes/model/grid/rl_grid_lcl_filter.py
+++ b/soft4pes/model/grid/rl_grid_lcl_filter.py
@@ -46,7 +46,7 @@ class RLGridLCLFilter(RLGrid):
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
     state_map : dict
-        A dictionary mapping state names to slices of the state vector.
+        A dictionary mapping states to elements of the state vector.
     """
 
     def __init__(self, par_grid, par_lcl_filter, conv, base):

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -47,14 +47,25 @@ class InductionMachine(SystemModel):
         Electrical angular rotor speed [p.u.].
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
+    state_map : dict
+        A dictionary mapping state names to slices of the state vector.
     """
 
     def __init__(self, par, conv, base, psiS_mag_ref, T_ref_init):
         self.par = par
         self.set_initial_state(psiS_mag_ref=psiS_mag_ref,
                                T_ref_init=T_ref_init)
-        super().__init__(par=par, conv=conv, base=base)
-        self.psiR_mag_ref = np.linalg.norm(self.x[2:4])
+        x_size = 4
+        state_map = {
+            'iS': slice(0, 2),  # Stator current (x[0:2])
+            'psiR': slice(2, 4),  # Rotor flux (x[2:4])
+        }
+        super().__init__(par=par,
+                         conv=conv,
+                         base=base,
+                         x_size=x_size,
+                         state_map=state_map)
+        self.psiR_mag_ref = np.linalg.norm(self.psiR)
 
     def set_initial_state(self, **kwargs):
         """
@@ -188,9 +199,8 @@ class InductionMachine(SystemModel):
 
     @property
     def Te(self):
-        iS = self.x[0:2]
-        psiR = self.x[2:4]
-        return self.par.kT * (self.par.Xm / self.par.Xr) * np.cross(psiR, iS)
+        return self.par.kT * (self.par.Xm / self.par.Xr) * np.cross(
+            self.psiR, self.iS)
 
     def get_next_state(self, matrices, u_abc, kTs):
         """

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -48,7 +48,7 @@ class InductionMachine(SystemModel):
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
     state_map : dict
-        A dictionary mapping state names to slices of the state vector.
+        A dictionary mapping states to elements of the state vector.
     """
 
     def __init__(self, par, conv, base, psiS_mag_ref, T_ref_init):


### PR DESCRIPTION
Add functionality for getting state variable values. For example, `sys.i_conv` will return the converter current value, i.e. x(1:2). This is advantageous, as it makes code more readable, reduces risk for making indices mistakes and need for conditions in code (see for example modification in `rfpsc.py`).

closes #94 

