### PR TITLE
Replace example file paths with developer package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ __pycache__/
 
 # Exclude documentation build
 docs/build
+
+# Build and distribution files
+*.egg-info/

--- a/README.md
+++ b/README.md
@@ -5,4 +5,11 @@ The aim is to develop optimal control methods for power electronic systems, such
 The library consists of building blocks that allow for modular solutions, allowing for adaptation of the methods to different systems.
 This work is under continuous development, so stay tuned!
 
-The API documentation of the library can be found at: https://tau-power-electronic-systems.github.io/Soft4PES/
+## Installation
+Installation instructions can be found at https://tau-power-electronic-systems.github.io/Soft4PES/
+
+## Examples
+In order to use the library, follow the installation instructions and see the `examples/` folder for complete usage examples of grid-connected converters and motor drives.
+
+## API documentation 
+The API documentation of the library can be found at: https://tau-power-electronic-systems.github.io/Soft4PES/autoapi/soft4pes/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ The aim is to develop optimal control methods for power electronic systems, such
 Installation
 ------------
 
-**Install Python**: Ensure that you have Python installed on your machine. You can download and install the latest version from the `official website <https://www.python.org/>`_.
+**Install Python**: Ensure that you have Python installed on your machine. You can download and install the latest version from the `official website <https://www.python.org/>`_. Using a Python distribution like MiniForge is recommended. 
 
 **Clone the Repository**: To get started, clone the repository to your local machine by running the following command in your terminal or command prompt::
 
@@ -18,9 +18,18 @@ Installation
 
    cd Soft4PES
 
-**Install Required Dependencies**: Install the required Python packages listed in the ``requirements.txt`` file. It is recommended to either create a virtual environment or ensure that Python is added to your system's PATH variable. To install the dependencies, run:::
+**Create a Virtual Environment (Optional)**: It is recommended to create a virtual environment to manage dependencies. Using MiniForge, you can create a virtual environment with the following command::
 
-   pip install -r requirements.txt
+   conda create -n soft4pes python=3.12
+   conda activate soft4pes
+
+Note: Python 3.13 is not yet supported.
+
+**Install Soft4PES in developer mode**: To install the library in developer mode, which allows you to make changes to the source code and have them reflected immediately, run the following command::
+
+   pip install -e .
+
+This step is required in order to run the examples. Note that all the required packages will be installed automatically.
 
 **Run Example**: The repository includes example files located in the ``examples`` folder. You can test the library by running an example script. For instance, to run a grid-forming control example, use the following command:::
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,7 +8,7 @@ The aim is to develop optimal control methods for power electronic systems, such
 Installation
 ------------
 
-**Install Python**: Ensure that you have Python installed on your machine. You can download and install the latest version from the `official website <https://www.python.org/>`_. Using a Python distribution like MiniForge is recommended. 
+**Install Python**: Ensure that you have Python installed on your machine. You can download and install the required version from the `official website <https://www.python.org/>`_. Using a Python distribution like MiniForge is recommended. The library is compatible with Python 3.12.
 
 **Clone the Repository**: To get started, clone the repository to your local machine by running the following command in your terminal or command prompt::
 

--- a/examples/grid/grid_forming_ctr.py
+++ b/examples/grid/grid_forming_ctr.py
@@ -5,28 +5,14 @@ synchronizes with the grid and generates the capacitor voltage reference, which 
 tracked by the cascade controller or MPC.
 """
 
-#pylint: disable=wrong-import-position
-#pylint: disable=wrong-import-order
-import sys as system
-import os
+from types import SimpleNamespace
 import numpy as np
 
-from types import SimpleNamespace
-
-## -------------------------------------------------------------------- ##
-# These allow using soft4pes from this folder
-# Get the directory of the current file and add the grandparent directory
-# (soft4pes) to the path
-current_dir = os.path.dirname(os.path.abspath(__file__))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..')))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
-## -------------------------------------------------------------------- ##
-
+from plotters.plot_grid_forming_ctr import plot_gfm_example
 from soft4pes import model
 from soft4pes.control import common, lin, mpc
 from soft4pes.utils import Sequence
 from soft4pes.sim import Simulation
-from plotters.plot_grid_forming_ctr import plot_gfm_example
 
 # Define the base values
 base = model.grid.BaseGrid(Vg_R_SI=400, Ig_R_SI=18, fg_R_SI=50)

--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -4,19 +4,8 @@ designed as a current controller, thus the main objective is to track the refere
 current. The current references are generated based on the power references. 
 """
 
-#pylint: disable=wrong-import-position
 from types import SimpleNamespace
-import sys as system
-import os
 import numpy as np
-
-## -------------------------------------------------------------------- ##
-# These allow using soft4pes from this folder
-# Get the directory of the current file and add the grandparent directory
-# (soft4pes) to the path
-current_dir = os.path.dirname(os.path.abspath(__file__))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
-## -------------------------------------------------------------------- ##
 
 from soft4pes import model
 from soft4pes.control import mpc, common, lin

--- a/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
+++ b/examples/grid/rl_grid_lcl_mpc_vc_ctr.py
@@ -4,21 +4,8 @@ MPC is designed as a capacitor voltage controller, thus the main objective is to
 capacitor voltage reference, while limiting the converter current. 
 """
 
-#pylint: disable=wrong-import-position
-#pylint: disable=wrong-import-order
-import sys as system
-import os
-import numpy as np
-
 from types import SimpleNamespace
-
-## -------------------------------------------------------------------- ##
-# These allow using soft4pes from this folder
-# Get the directory of the current file and add the grandparent directory
-# (soft4pes) to the path
-current_dir = os.path.dirname(os.path.abspath(__file__))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
-## -------------------------------------------------------------------- ##
+import numpy as np
 
 from soft4pes import model
 from soft4pes.control import mpc, common

--- a/examples/grid/rl_grid_state_space_curr_ctr.py
+++ b/examples/grid/rl_grid_state_space_curr_ctr.py
@@ -3,19 +3,7 @@ Example of state-space control for a grid-connected power converter. The control
 track the reference of the grid current.
 """
 
-#pylint: disable=wrong-import-position
-import sys as system
-import os
-
 import numpy as np
-
-## -------------------------------------------------------------------- ##
-# These allow using soft4pes from this folder
-# Get the directory of the current file and add the grandparent directory
-# (soft4pes) to the path
-current_dir = os.path.dirname(os.path.abspath(__file__))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
-## -------------------------------------------------------------------- ##
 
 from soft4pes import model
 from soft4pes.control.lin import RLGridStateSpaceCurrCtr

--- a/examples/machine/im_direct_mpc_curr_ctr.py
+++ b/examples/machine/im_direct_mpc_curr_ctr.py
@@ -4,19 +4,8 @@ controller aims to track the stator current reference calculated based on the re
 the stator flux magnitude and torque. The machine operates at a constant (nominal) speed.
 """
 
-#pylint: disable=wrong-import-position
 from types import SimpleNamespace
-import sys as system
-import os
 import numpy as np
-
-## -------------------------------------------------------------------- ##
-# These allow using soft4pes from this folder
-# Get the directory of the current file and add the grandparent directory
-# (soft4pes) to the path
-current_dir = os.path.dirname(os.path.abspath(__file__))
-system.path.append(os.path.abspath(os.path.join(current_dir, '..', '..')))
-## -------------------------------------------------------------------- ##
 
 from soft4pes import model
 from soft4pes.control import mpc, common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,4 +11,4 @@ dependencies = [
     "matplotlib",
     "qpsolvers[daqp]",
 ]
-requires-python = ">=3.12"
+requires-python = "=3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["setuptools>=45", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "soft4pes"
+version = "0.1.0"
+dependencies = [
+    "numpy",
+    "scipy", 
+    "matplotlib",
+    "qpsolvers[daqp]",
+]
+requires-python = ">=3.12"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-numpy
-scipy
-matplotlib
-qpsolvers[daqp]


### PR DESCRIPTION
This PR removes hard coded file paths from example files and updates the installation instructions. The installation is now instructed to be done by creating a developer package, essentially creating a package out of `soft4pes` folder. 

The installation is now done using `pip install -e .`. The line has to be run again, if we 

- Change `pyproject.toml` - version, dependencies, metadata
- Add new dependencies to the project
- Add new top-level packages (new directories under `soft4pes`

closes #106 