### PR TITLE
Add PMSM alpha-beta model

### DIFF
--- a/examples/machine/pars/machine_config.py
+++ b/examples/machine/pars/machine_config.py
@@ -101,7 +101,7 @@ def create_machine_parameters(machine_params, base):
             Rs_SI=machine_params["Rs_SI"],
             Lsd_SI=machine_params["Lsd_SI"],
             Lsq_SI=machine_params["Lsq_SI"],
-            LambdaPM_SI=machine_params["LambdaPM_SI"],
+            Lambda_PM_SI=machine_params["Lambda_PM_SI"],
             base=base)
     raise ValueError(f"Unknown machine type: {machine_type}")
 

--- a/examples/machine/pars/machine_parameter_sets.json
+++ b/examples/machine/pars/machine_parameter_sets.json
@@ -36,7 +36,7 @@
             "Rs_SI": 0.3,
             "Lsd_SI": 4.5e-3,
             "Lsq_SI": 5.5e-3,
-            "LambdaPM_SI": 0.7
+            "Lambda_PM_SI": 0.7
         }
     },
     "converters": {

--- a/examples/machine/pmsm_direct_mpc_curr_ctr.py
+++ b/examples/machine/pmsm_direct_mpc_curr_ctr.py
@@ -15,36 +15,35 @@ from soft4pes.sim import Simulation
 from soft4pes.utils.plotter import Plotter
 
 # Define base values
-# Example PMSM (https://ieeexplore.ieee.org/document/10227497)
-base = model.machine.BaseMachine(Vm_R_SI=318,
-                                 Im_R_SI=138,
-                                 fm_R_SI=120,
+base = model.machine.BaseMachine(Vm_R_SI=274,
+                                 Im_R_SI=71,
+                                 fm_R_SI=50,
                                  npp=4,
-                                 pf=0.86)
+                                 pf=1)
 
 # Define torque reference sequence
 # The first array contains the time instants (in seconds) and the second array the corresponding
 # reference values (in per unit). The reference is interpolated linearly between the time instants.
 T_ref_seq = Sequence(
-    np.array([0, 0.05, 0.05, 0.1, 0.1, 0.15]),
-    np.array([0, 0, 0.5, 0.5, 1, 1]),
+    np.array([0, 0.05, 0.05, 0.1]),
+    np.array([0, 0, 1, 1]),
 )
 ref_seq = SimpleNamespace(T_ref_seq=T_ref_seq)
 
 # Define PMSM parameters
-sm_params = model.machine.PMSMParameters(fs_SI=120,
-                                         pf_SI=0.86,
-                                         Rs_SI=0.046,
-                                         Lsd_SI=1.58e-3,
-                                         Lsq_SI=6.48e-3,
-                                         LambdaPM_SI=0.684,
+sm_params = model.machine.PMSMParameters(fs_SI=50,
+                                         pf_SI=1,
+                                         Rs_SI=0.3,
+                                         Lsd_SI=4.5e-3,
+                                         Lsq_SI=5.5e-3,
+                                         LambdaPM_SI=0.7,
                                          base=base)
 
 # Create a MTPA lookup table for current reference calculation
 MPTA_lut = common.MTPALookupTable(par=sm_params)
 
 # Define system models. The MTPA lookup table is passed to the PMSM model to set the initial state.
-conv = model.conv.Converter(v_dc_SI=980, nl=2, base=base)
+conv = model.conv.Converter(v_dc_SI=570, nl=2, base=base)
 sys = model.machine.PMSM(par=sm_params,
                          conv=conv,
                          base=base,
@@ -55,23 +54,25 @@ sys = model.machine.PMSM(par=sm_params,
 solver = mpc.solvers.MpcBnB(conv=conv)
 
 # Define current controller
-ctr = mpc.controllers.SMMpcCurrCtr(solver,
-                                   lambda_u=1e-3,
-                                   Np=2,
-                                   disc_method='forward_euler')
+ctr = mpc.controllers.PMSMMpcCurrCtr(
+    solver,
+    lambda_u=1e-3,
+    Np=2,
+    disc_method='forward_euler',
+)
 
 # Define control system, which includes the MTPA lookup table as an outer control loop and the MPC
 # current controller as an inner control loop
 ctr_sys = common.ControlSystem(control_loops=[MPTA_lut, ctr],
                                ref_seq=ref_seq,
-                               Ts=25e-6)
+                               Ts=50e-6)
 
 # Simulate system
 sim = Simulation(sys=sys,
                  ctr=ctr_sys,
-                 Ts_sim=25e-6,
+                 Ts_sim=50e-6,
                  disc_method='forward_euler')
-sim_data = sim.simulate(t_stop=0.15)
+sim_data = sim.simulate(t_stop=0.1)
 sim.save_data()
 
 # Plot results

--- a/examples/machine/pmsm_direct_mpc_curr_ctr.py
+++ b/examples/machine/pmsm_direct_mpc_curr_ctr.py
@@ -40,7 +40,7 @@ sm_params = model.machine.PMSMParameters(fs_SI=50,
                                          Rs_SI=0.3,
                                          Lsd_SI=4.5e-3,
                                          Lsq_SI=5.5e-3,
-                                         LambdaPM_SI=0.7,
+                                         Lambda_PM_SI=0.7,
                                          base=base)
 
 # Uncomment the following lines to use the ready made configuration. All the available components

--- a/soft4pes/control/common/pmsm_mtpa.py
+++ b/soft4pes/control/common/pmsm_mtpa.py
@@ -6,8 +6,8 @@ class MTPALookupTable(Controller):
     """
     Maximum Torque Per Ampere (MTPA) lookup table for permanent magnet synchronous machines (PMSM).
     
-    This class generates and manages the MTPA trajectory, providing optimal
-    current references for given torque demands.
+    This class generates and manages the MTPA trajectory, providing optimal current references for 
+    given torque demands.
     """
 
     def __init__(self, par, iS_mag_points=101, theta_points=2001):

--- a/soft4pes/control/common/pmsm_mtpa.py
+++ b/soft4pes/control/common/pmsm_mtpa.py
@@ -21,50 +21,84 @@ class MTPALookupTable(Controller):
         iS_mag_points : int, optional
             Number of stator current magnitude points for trajectory generation. Default is 101.
         theta_points : int, optional
-            Number of angle points for trajectory generation. Default is 2001.
+            Number of current vector angle points for trajectory generation. Default is 2001.
         """
         super().__init__()
         self.par = par
         self.iS_mag_points = iS_mag_points
         self.theta_points = theta_points
-        self.mtpa_lut = {}  # Dictionary: {torque: iS_dq}
+        self.torque_grid = None
+        self.current_grid = None
         self.generate_mtpa_trajectory()
 
     def generate_mtpa_trajectory(self):
         """
-        Generate the maximum torque per ampere (MTPA) trajectory.
+        Generate the maximum torque per ampere (MTPA) trajectory for both positive and negative 
+        torque.
         
-        Creates a lookup table mapping torque values to optimal stator current references.
+        The algorithm sweeps current magnitude from 0 to 1 p.u. and for each magnitude finds the
+        current vector orientations that produce maximum positive and negative torque. Results are
+        stored as sorted arrays for efficient interpolation.
+        
+        Creates
+        -------
+        self.torque_grid : ndarray
+            Sorted array of achievable torque values [p.u.].
+        self.current_grid : ndarray
+            Array of optimal current vectors [id, iq] corresponding to torque_grid [p.u.].
         """
-
         iS_mag_range = np.linspace(0, 1, self.iS_mag_points)
-        theta_range = np.linspace(0, np.pi / 2, self.theta_points)
+        theta_range = np.linspace(-np.pi / 2, np.pi / 2, self.theta_points)
+
+        torques = []
+        currents = []
 
         for iS_mag in iS_mag_range:
+            # Skip zero current magnitude (produces only zero torque)
+            if iS_mag == 0:
+                continue
+
             id_trajectory = -iS_mag * np.cos(theta_range)
             iq_trajectory = iS_mag * np.sin(theta_range)
 
-            # Calculate torque map for this current magnitude
-            Te_map = np.dot(
-                iq_trajectory.reshape(-1, 1),
-                (self.par.Xsd - self.par.Xsq) * id_trajectory.reshape(1, -1) +
-                self.par.PsiPM)
+            # Calculate torque for each angle
+            Te_line = iq_trajectory * (
+                (self.par.Xsd - self.par.Xsq) * id_trajectory + self.par.PsiPM)
 
-            # Extract diagonal (optimal torque for each angle)
-            Te_line = [Te_map[kk, kk] for kk in range(theta_range.size)]
+            # Find maximum positive torque
+            max_pos_index = np.argmax(Te_line)
+            max_pos_torque = Te_line[max_pos_index]
 
-            # Find maximum torque and corresponding currents
-            max_index = np.argmax(Te_line)
-            optimal_torque = Te_line[max_index]
-            optimal_iS_dq = np.array(
-                [id_trajectory[max_index], iq_trajectory[max_index]])
+            # Find maximum negative torque
+            min_neg_index = np.argmin(Te_line)
+            min_neg_torque = Te_line[min_neg_index]
 
-            # Store in lookup table
-            self.mtpa_lut[optimal_torque] = optimal_iS_dq
+            # Store positive optimal point
+            if max_pos_torque > 0:
+                torques.append(max_pos_torque)
+                currents.append([
+                    id_trajectory[max_pos_index], iq_trajectory[max_pos_index]
+                ])
+
+            # Store negative optimal point
+            if min_neg_torque < 0:
+                torques.append(min_neg_torque)
+                currents.append([
+                    id_trajectory[min_neg_index], iq_trajectory[min_neg_index]
+                ])
+
+        # Add explicit zero torque point
+        torques.append(0.0)
+        currents.append([0.0, 0.0])
+
+        # Sort by torque and store as arrays
+        sorted_indices = np.argsort(torques)
+        self.torque_grid = np.array(torques)[sorted_indices]
+        self.current_grid = np.array(currents)[sorted_indices]
 
     def get_optimal_current(self, Te_ref):
         """
-        Get optimal stator current reference for given torque reference.
+        Get optimal stator current reference for given torque reference using linear interpolation.
         
         Parameters
         ----------
@@ -77,11 +111,10 @@ class MTPALookupTable(Controller):
             Optimal stator current reference [p.u.].
         """
 
-        # Find closest torque value in lookup table
-        closest_torque = min(self.mtpa_lut.keys(),
-                             key=lambda torque: abs(torque - Te_ref))
-
-        return np.array(self.mtpa_lut[closest_torque])
+        # Linear interpolation for better coverage
+        id_ref = np.interp(Te_ref, self.torque_grid, self.current_grid[:, 0])
+        iq_ref = np.interp(Te_ref, self.torque_grid, self.current_grid[:, 1])
+        return np.array([id_ref, iq_ref])
 
     def execute(self, sys, kTs):
         """

--- a/soft4pes/control/common/pmsm_mtpa.py
+++ b/soft4pes/control/common/pmsm_mtpa.py
@@ -37,8 +37,9 @@ class MTPALookupTable(Controller):
         torque.
         
         The algorithm sweeps current magnitude from 0 to 1 p.u. and for each magnitude finds the
-        current vector orientations that produce maximum positive and negative torque. Results are
-        stored as sorted arrays for efficient interpolation.
+        current vector angle (and therefore the d and q components of the current) that produces the 
+        maximum positive and negative torque. Results are stored as sorted arrays for efficient 
+        interpolation.
         
         Creates
         -------
@@ -63,7 +64,8 @@ class MTPALookupTable(Controller):
 
             # Calculate torque for each angle
             Te_line = iq_trajectory * (
-                (self.par.Xsd - self.par.Xsq) * id_trajectory + self.par.PsiPM)
+                (self.par.Xsd - self.par.Xsq) * id_trajectory +
+                self.par.Psi_PM)
 
             # Find maximum positive torque
             max_pos_index = np.argmax(Te_line)

--- a/soft4pes/control/mpc/controllers/__init__.py
+++ b/soft4pes/control/mpc/controllers/__init__.py
@@ -5,12 +5,12 @@ Model predictive control (MPC) for power electronic systems.
 
 from soft4pes.control.mpc.controllers.lcl_vc_mpc_ctr import LCLVcMpcCtr
 from soft4pes.control.mpc.controllers.im_mpc_curr_ctr import IMMpcCurrCtr
-from soft4pes.control.mpc.controllers.sm_mpc_curr_ctr import SMMpcCurrCtr
+from soft4pes.control.mpc.controllers.pmsm_mpc_curr_ctr import PMSMMpcCurrCtr
 from soft4pes.control.mpc.controllers.rl_grid_mpc_curr_ctr import RLGridMpcCurrCtr
 
 __all__ = [
     "LCLVcMpcCtr",
     "IMMpcCurrCtr",
-    "SMMpcCurrCtr",
+    "PMSMMpcCurrCtr",
     "RLGridMpcCurrCtr",
 ]

--- a/soft4pes/control/mpc/controllers/pmsm_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/pmsm_mpc_curr_ctr.py
@@ -3,10 +3,10 @@
 from types import SimpleNamespace
 import numpy as np
 from soft4pes.control.common.controller import Controller
-from soft4pes.utils.conversions import alpha_beta_2_dq, dq_2_alpha_beta
+from soft4pes.utils.conversions import dq_2_alpha_beta, alpha_beta_2_dq
 
 
-class SMMpcCurrCtr(Controller):
+class PMSMMpcCurrCtr(Controller):
     """
     Model predictive current control for a permanent magnet synchronous machine (PMSM). 
     The controller aims to track the stator current reference, provided by the outer loop or user.
@@ -50,7 +50,7 @@ class SMMpcCurrCtr(Controller):
         self.solver = solver
 
         # Output matrix
-        self.C = np.array([[1, 0], [0, 1]])
+        self.C = np.array([[1, 0, 0, 0], [0, 1, 0, 0]])
 
     def execute(self, sys, kTs):
         """
@@ -91,7 +91,6 @@ class SMMpcCurrCtr(Controller):
         self.u_km1_abc = u_abc
 
         self.output = SimpleNamespace(u_abc=u_abc)
-
         return self.output
 
     def get_next_state(self, sys, xk, u_abc, k):
@@ -121,8 +120,5 @@ class SMMpcCurrCtr(Controller):
         self.state_space = sys.get_discrete_state_space(
             self.Ts, self.disc_method)
 
-        xk_dq = alpha_beta_2_dq(xk, sys.theta_el)
-        x_kp1_dq = np.dot(self.state_space.A, xk_dq) + np.dot(
-            self.state_space.B1, u_abc) + self.state_space.B2
-
-        return dq_2_alpha_beta(x_kp1_dq, sys.theta_el)
+        return np.dot(self.state_space.A, xk) + np.dot(self.state_space.B,
+                                                       u_abc)

--- a/soft4pes/control/mpc/controllers/pmsm_mpc_curr_ctr.py
+++ b/soft4pes/control/mpc/controllers/pmsm_mpc_curr_ctr.py
@@ -3,7 +3,7 @@
 from types import SimpleNamespace
 import numpy as np
 from soft4pes.control.common.controller import Controller
-from soft4pes.utils.conversions import dq_2_alpha_beta, alpha_beta_2_dq
+from soft4pes.utils.conversions import dq_2_alpha_beta
 
 
 class PMSMMpcCurrCtr(Controller):
@@ -50,7 +50,7 @@ class PMSMMpcCurrCtr(Controller):
         self.solver = solver
 
         # Output matrix
-        self.C = np.array([[1, 0, 0, 0], [0, 1, 0, 0]])
+        self.C = np.eye(2)
 
     def execute(self, sys, kTs):
         """
@@ -114,11 +114,18 @@ class PMSMMpcCurrCtr(Controller):
             The next state of the system.
         """
 
+        # Get the rotor flux at step k by rotating it
+        Ts_pu = self.Ts * sys.base.w
+        delta_theta = k * sys.par.ws * Ts_pu
+        R = np.array([[np.cos(delta_theta), -np.sin(delta_theta)], \
+                        [np.sin(delta_theta), np.cos(delta_theta)]])
+        psi_PM_k = np.dot(R, sys.psi_PM)
+
         # Assume that the electrical rotor angle varies slowly, and the model is constant over the
         # prediction horizon
         sys.cont_state_space = sys.get_continuous_state_space()
         self.state_space = sys.get_discrete_state_space(
             self.Ts, self.disc_method)
 
-        return np.dot(self.state_space.A, xk) + np.dot(self.state_space.B,
-                                                       u_abc)
+        return np.dot(self.state_space.A, xk) + np.dot(
+            self.state_space.B, u_abc) + np.dot(self.state_space.B2, psi_PM_k)

--- a/soft4pes/model/common/system_model.py
+++ b/soft4pes/model/common/system_model.py
@@ -164,7 +164,7 @@ class SystemModel(ABC):
         """
 
     @abstractmethod
-    def get_next_state(self, matrices, u_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs, Ts):
         """
         Calculate the next state of the system.
 
@@ -192,7 +192,7 @@ class SystemModel(ABC):
             Current discrete time instant [s].
         """
 
-    def update_state(self, matrices, u_abc, kTs):
+    def update_state(self, matrices, u_abc, kTs, Ts):
         """
         Update the system state and save data.
 
@@ -210,8 +210,7 @@ class SystemModel(ABC):
 
         meas = self.get_measurements(kTs)
         self.save_data(kTs, u_abc, meas)
-        self.x = self.get_next_state(matrices, u_abc, kTs)
-        self.update_internal_variables(kTs)
+        self.x = self.get_next_state(matrices, u_abc, kTs, Ts)
 
     def save_data(self, kTs, u_abc, meas):
         """
@@ -235,14 +234,3 @@ class SystemModel(ABC):
                 if not hasattr(self.data, key):
                     setattr(self.data, key, [])
                 getattr(self.data, key).append(value)
-
-    @abstractmethod
-    def update_internal_variables(self, kTs):
-        """
-        Update internal variables of the system.
-
-        Parameters
-        ----------
-        kTs : float
-            Current discrete time instant [s].
-        """

--- a/soft4pes/model/grid/rl_grid.py
+++ b/soft4pes/model/grid/rl_grid.py
@@ -128,7 +128,7 @@ class RLGrid(SystemModel):
         vg = abc_2_alpha_beta(vg_abc)
         return vg
 
-    def get_next_state(self, matrices, u_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs, Ts):
         """
         Calculate the next state of the system.
 
@@ -140,6 +140,8 @@ class RLGrid(SystemModel):
             A SimpleNamespace object containing the state-space model matrices.
         kTs : float
             Current discrete time instant [s].
+        Ts : float
+            Sampling interval [s] (not used).
 
         Returns
         -------
@@ -168,13 +170,3 @@ class RLGrid(SystemModel):
         """
 
         return SimpleNamespace(vg=self.get_grid_voltage(kTs))
-
-    def update_internal_variables(self, kTs):
-        """
-        Update internal variables of the system.
-
-        Parameters
-        ----------
-        kTs : float
-            Current discrete time instant [s].
-        """

--- a/soft4pes/model/machine/induction_machine.py
+++ b/soft4pes/model/machine/induction_machine.py
@@ -201,7 +201,7 @@ class InductionMachine(SystemModel):
     def Te(self):
         return (self.par.Xm / self.par.Xr) * np.cross(self.psiR, self.iS)
 
-    def get_next_state(self, matrices, u_abc, kTs):
+    def get_next_state(self, matrices, u_abc, kTs, Ts):
         """
         Calculate the next state of the system.
 
@@ -212,7 +212,10 @@ class InductionMachine(SystemModel):
         matrices : SimpleNamespace
             A SimpleNamespace object containing the state-space model matrices.
         kTs : float
-            Current discrete time instant [s].
+            Current discrete time instant [s] (not used).
+        Ts : float
+            Sampling interval [s] (not used).
+
 
         Returns
         -------
@@ -238,13 +241,3 @@ class InductionMachine(SystemModel):
             A SimpleNamespace object containing the machine torque.
         """
         return SimpleNamespace(Te=self.Te)
-
-    def update_internal_variables(self, kTs):
-        """
-        Update internal variables of the system.
-
-        Parameters
-        ----------
-        kTs : float
-            Current discrete time instant [s].
-        """

--- a/soft4pes/model/machine/pmsm.py
+++ b/soft4pes/model/machine/pmsm.py
@@ -1,6 +1,6 @@
 """
 Permanent magnet synchronous machine (PMSM) model. The machine operates at a constant electrical 
-angular rotor speed. The machine model is from 
+angular rotor speed. 
 """
 
 from types import SimpleNamespace

--- a/soft4pes/model/machine/pmsm.py
+++ b/soft4pes/model/machine/pmsm.py
@@ -1,6 +1,6 @@
 """
 Permanent magnet synchronous machine (PMSM) model. The machine operates at a constant electrical 
-angular rotor speed.
+angular rotor speed. The machine model is from 
 """
 
 from types import SimpleNamespace
@@ -12,9 +12,17 @@ from soft4pes.utils.conversions import alpha_beta_2_dq, dq_2_alpha_beta
 class PMSM(SystemModel):
     """
     Permanent magnet synchronous machine (PMSM) model. The model operates at a constant electrical
-    angular rotor speed. The system is modelled in a dq-frame, where the d-axis is aligned with the
-    rotor flux. However, the state of the system is the stator current in the alpha-beta frame, and
-    thus reference frame conversions are performed during state updates.
+    angular rotor speed. The system is modelled in a alpha-beta frame. The state of the system is 
+    the stator current and rotor flux, i.e. [iS_alpha, iS_beta, psiR_alpha, psiR_beta]^T. The 
+    system input is the converter three-phase switch position or modulating signal. The initial 
+    state of the model is based on the torque reference and the electrical angle, set to -pi/2 rad
+    at t = 0 s.
+
+    Note that although the rotor flux appears as a state of the system, it is generated using the 
+    electrical angle and the permanent magnet flux linkage at the state update. This approach avoids 
+    numerical integration errors that would accumulate when using Forward Euler discretization for 
+    the rotor flux dynamics, since the rotor flux magnitude is constant and only rotates with the 
+    electrical angle. The full state-space model is still used in the MPC state predictions.
 
     Parameters
     ----------
@@ -26,10 +34,8 @@ class PMSM(SystemModel):
         Base values.
     T_ref_init : float
         Initial torque reference [p.u.].
-    i_mag_points : int, optional
-        Number of current magnitude points for MTPA trajectory generation. The default is 101.
-    theta_points : int, optional
-        Number of angle points for MTPA trajectory generation. The default is 2001.
+    mtpa_lut : MTPALookupTable
+        MTPA lookup table for optimal current calculation.
 
     Attributes
     ----------
@@ -41,29 +47,26 @@ class PMSM(SystemModel):
         Converter object.
     base : base value object
         Base values.
-    x : 1 x 2 ndarray of floats
+    x : 1 x 4 ndarray of floats
         Current state of the machine [p.u.].
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
     state_map : dict
-        A dictionary mapping states to elements of the state vector.
+        A dictionary mapping state names to elements of the state vector.
     time_varying_model : bool
         Indicates if the system model is time-varying.
-    mtpa : MTPALookupTable
-        Maximum torque per ampere (MTPA) lookup table.
     theta_el : float
         Electrical angle of the machine [rad].
     """
 
     def __init__(self, par, conv, base, T_ref_init, mtpa_lut):
-        self.par = par
-        self.theta_el = 0
-        self.set_initial_state(T_ref_init=T_ref_init, mtpa_lut=mtpa_lut)
-
-        x_size = 2
+        x_size = 4
         state_map = {
             'iS': slice(0, 2),  # Stator current (x[0:2])
+            'psiR': slice(2, 4),  # Rotor flux linkage (x[2:4])
         }
+        self.theta_el = -np.pi / 2
+
         super().__init__(par=par,
                          conv=conv,
                          base=base,
@@ -71,14 +74,20 @@ class PMSM(SystemModel):
                          state_map=state_map)
         self.time_varying_model = True
 
+        self.set_initial_state(T_ref_init=T_ref_init, mtpa_lut=mtpa_lut)
+
     def set_initial_state(self, **kwargs):
         """
-        Calculates the initial state (stator current) of the machine based on the torque reference.
+        Calculate the initial state of the machine based on the torque reference.
 
         Parameters
         ----------
-        T_ref_init : float
-            The initial torque reference [p.u.].
+        **kwargs : dict
+            Keyword arguments containing:
+            - T_ref_init : float
+                The initial torque reference [p.u.].
+            - mtpa_lut : MTPALookupTable
+                MTPA lookup table for optimal current calculation.
         """
 
         T_ref_init = kwargs.get('T_ref_init')
@@ -86,7 +95,9 @@ class PMSM(SystemModel):
 
         # Get the initial stator current from MTPA
         iS_dq = mtpa_lut.get_optimal_current(T_ref_init)
-        self.x = dq_2_alpha_beta(iS_dq, self.theta_el)
+        iS = dq_2_alpha_beta(iS_dq, self.theta_el)
+        psiR = self.psiR
+        self.x = np.concatenate((iS, psiR))
 
     def get_stator_current_ref_dq(self, T_ref):
         """
@@ -111,67 +122,88 @@ class PMSM(SystemModel):
         Returns
         -------
         SimpleNamespace
-            A SimpleNamespace object containing matrices F, G1, and G2 of the continuous-time 
-            state-space model.
+            A SimpleNamespace object containing matrices F and G of the continuous-time state-space 
+            model.
         """
 
         ws = self.par.ws
         Rs = self.par.Rs
         Xsd = self.par.Xsd
         Xsq = self.par.Xsq
-        PsiPM = self.par.PsiPM
 
         K = (2 / 3) * np.array([[1, -1 / 2, -1 / 2],
                                 [0, np.sqrt(3) / 2, -np.sqrt(3) / 2]])
 
-        R = np.array([[np.cos(self.theta_el),
-                       np.sin(self.theta_el)],
-                      [-np.sin(self.theta_el),
-                       np.cos(self.theta_el)]])
+        Xs = (Xsd + Xsq) / 2
+        delta_X = Xsd - Xsq
+        X_theta = np.array([[Xs + delta_X * np.cos(2 * self.theta_el) / 2, \
+                             delta_X * np.sin(2 * self.theta_el) / 2],
+                            [delta_X * np.sin(2 * self.theta_el) / 2, \
+                             Xs - delta_X * np.cos(2 * self.theta_el) / 2]])
+        J = np.array([[0, -1], [1, 0]])
 
-        F = np.array([[-Rs / Xsd, ws * Xsq / Xsd],
-                      [-ws * Xsd / Xsq, -Rs / Xsq]])
+        R = np.array([[-np.sin(2 * self.theta_el),
+                       np.cos(2 * self.theta_el)],
+                      [np.cos(2 * self.theta_el),
+                       np.sin(2 * self.theta_el)]])
 
-        G1 = np.dot(np.dot(np.array([[1 / Xsd, 0], [0, 1 / Xsq]]), R),
-                    K) * self.conv.v_dc / 2
+        X_theta_inv = np.linalg.inv(X_theta)
 
-        G2 = np.array([0, -ws * PsiPM / Xsq])
+        F11 = -X_theta_inv.dot(Rs * np.eye(2) + ws * delta_X * R)
+        F12 = -ws * X_theta_inv.dot(J)
+        F21 = np.zeros((2, 2))
+        F22 = ws * J
+        F = np.block([[F11, F12], [F21, F22]])
 
-        return SimpleNamespace(F=F, G1=G1, G2=G2)
+        G = self.conv.v_dc / 2 * np.vstack(
+            [np.eye(2), np.zeros((2, 2))]).dot(X_theta_inv).dot(K)
+
+        return SimpleNamespace(F=F, G=G)
 
     @property
     def Te(self):
-        iS_dq = alpha_beta_2_dq(self.x, self.theta_el)
+        iS_dq = alpha_beta_2_dq(self.iS, self.theta_el)
         return ((self.par.Xsd - self.par.Xsq) * iS_dq[0] +
                 self.par.PsiPM) * iS_dq[1]
 
-    def get_next_state(self, matrices, u_abc, kTs):
+    @property
+    def psiR(self):
+        return np.array([np.cos(self.theta_el),
+                         np.sin(self.theta_el)]) * self.par.PsiPM
+
+    def get_next_state(self, matrices, u_abc, kTs, Ts):
         """
         Calculate the next state of the system.
 
         Parameters
         ----------
-        u_abc : 1 x 3 ndarray of floats
-            Converter three-phase switch position or modulating signal.
         matrices : SimpleNamespace
-            A SimpleNamespace object containing the state-space model matrices.
+            A SimpleNamespace object containing the state-space model matrices A and B.
+        u_abc : 1 x 3 ndarray of floats
+            Converter three-phase switch position or modulating signal [p.u.].
         kTs : float
             Current discrete time instant [s].
+        Ts : float
+            Sampling interval [s].
 
         Returns
         -------
-        1 x 2 ndarray of floats
+        1 x 4 ndarray of floats
             The next state of the system.
         """
 
-        x_dq = alpha_beta_2_dq(self.x, self.theta_el)
-        x_kp1_dq = np.dot(matrices.A, x_dq) + np.dot(matrices.B1,
-                                                     u_abc) + matrices.B2
-        return dq_2_alpha_beta(x_kp1_dq, self.theta_el)
+        # Get the next state
+        x = np.concatenate((self.iS, self.psiR))
+        x_kp1 = np.dot(matrices.A, x) + np.dot(matrices.B, u_abc)
+
+        # Update electrical angle
+        self.theta_el += self.par.ws * Ts * self.base.w
+
+        return x_kp1
 
     def get_measurements(self, kTs):
         """
-        Update the measurement data of the system.
+        Get the measurement data of the system.
 
         Parameters
         ----------
@@ -181,19 +213,7 @@ class PMSM(SystemModel):
         Returns
         -------
         SimpleNamespace
-            A SimpleNamespace object containing the machine torque and rotor electrical angle.
+            A SimpleNamespace object containing the machine electromagnetic torque Te [p.u.].
         """
 
-        return SimpleNamespace(Te=self.Te, theta_el=self.theta_el)
-
-    def update_internal_variables(self, kTs):
-        """
-        Update the electrical rotor angle of the machine.
-
-        Parameters
-        ----------
-        kTs : float
-            Current discrete time instant [s].
-        """
-
-        self.theta_el = kTs * self.par.ws * self.base.w
+        return SimpleNamespace(Te=self.Te)

--- a/soft4pes/model/machine/pmsm.py
+++ b/soft4pes/model/machine/pmsm.py
@@ -11,18 +11,11 @@ from soft4pes.utils.conversions import alpha_beta_2_dq, dq_2_alpha_beta
 
 class PMSM(SystemModel):
     """
-    Permanent magnet synchronous machine (PMSM) model. The model operates at a constant electrical
-    angular rotor speed. The system is modelled in a alpha-beta frame. The state of the system is 
-    the stator current and rotor flux, i.e. [iS_alpha, iS_beta, psiR_alpha, psiR_beta]^T. The 
-    system input is the converter three-phase switch position or modulating signal. The initial 
-    state of the model is based on the torque reference and the electrical angle, set to -pi/2 rad
-    at t = 0 s.
-
-    Note that although the rotor flux appears as a state of the system, it is generated using the 
-    electrical angle and the permanent magnet flux linkage at the state update. This approach avoids 
-    numerical integration errors that would accumulate when using Forward Euler discretization for 
-    the rotor flux dynamics, since the rotor flux magnitude is constant and only rotates with the 
-    electrical angle. The full state-space model is still used in the MPC state predictions.
+    Permanent magnet synchronous machine (PMSM) model. The system is modeled in a alpha-beta frame, 
+    and the machine operates at a constant electrical angular rotor speed. The state of the system 
+    is the stator current, and the permanent-magnet flux (i.e., rotor flux) is considered as a 
+    disturbance. The system input is the converter three-phase switch position or modulating signal.
+    The initial state of the model is based on the torque reference.
 
     Parameters
     ----------
@@ -47,7 +40,7 @@ class PMSM(SystemModel):
         Converter object.
     base : base value object
         Base values.
-    x : 1 x 4 ndarray of floats
+    x : 1 x 2 ndarray of floats
         Current state of the machine [p.u.].
     cont_state_space : SimpleNamespace
         The continuous-time state-space model of the system.
@@ -63,7 +56,6 @@ class PMSM(SystemModel):
         x_size = 4
         state_map = {
             'iS': slice(0, 2),  # Stator current (x[0:2])
-            'psiR': slice(2, 4),  # Rotor flux linkage (x[2:4])
         }
         self.theta_el = -np.pi / 2
 
@@ -96,8 +88,7 @@ class PMSM(SystemModel):
         # Get the initial stator current from MTPA
         iS_dq = mtpa_lut.get_optimal_current(T_ref_init)
         iS = dq_2_alpha_beta(iS_dq, self.theta_el)
-        psiR = self.psiR
-        self.x = np.concatenate((iS, psiR))
+        self.x = iS
 
     def get_stator_current_ref_dq(self, T_ref):
         """
@@ -149,27 +140,22 @@ class PMSM(SystemModel):
 
         X_theta_inv = np.linalg.inv(X_theta)
 
-        F11 = -X_theta_inv.dot(Rs * np.eye(2) + ws * delta_X * R)
-        F12 = -ws * X_theta_inv.dot(J)
-        F21 = np.zeros((2, 2))
-        F22 = ws * J
-        F = np.block([[F11, F12], [F21, F22]])
+        F = -X_theta_inv.dot(Rs * np.eye(2) + ws * delta_X * R)
+        G = self.conv.v_dc / 2 * X_theta_inv.dot(K)
+        G2 = -ws * X_theta_inv.dot(J)
 
-        G = self.conv.v_dc / 2 * np.vstack(
-            [np.eye(2), np.zeros((2, 2))]).dot(X_theta_inv).dot(K)
-
-        return SimpleNamespace(F=F, G=G)
+        return SimpleNamespace(F=F, G=G, G2=G2)
 
     @property
     def Te(self):
         iS_dq = alpha_beta_2_dq(self.iS, self.theta_el)
         return ((self.par.Xsd - self.par.Xsq) * iS_dq[0] +
-                self.par.PsiPM) * iS_dq[1]
+                self.par.Psi_PM) * iS_dq[1]
 
     @property
-    def psiR(self):
+    def psi_PM(self):
         return np.array([np.cos(self.theta_el),
-                         np.sin(self.theta_el)]) * self.par.PsiPM
+                         np.sin(self.theta_el)]) * self.par.Psi_PM
 
     def get_next_state(self, matrices, u_abc, kTs, Ts):
         """
@@ -193,8 +179,8 @@ class PMSM(SystemModel):
         """
 
         # Get the next state
-        x = np.concatenate((self.iS, self.psiR))
-        x_kp1 = np.dot(matrices.A, x) + np.dot(matrices.B, u_abc)
+        x_kp1 = np.dot(matrices.A, self.x) + np.dot(
+            matrices.B, u_abc) + np.dot(matrices.B2, self.psi_PM)
 
         # Update electrical angle
         self.theta_el += self.par.ws * Ts * self.base.w
@@ -216,4 +202,4 @@ class PMSM(SystemModel):
             A SimpleNamespace object containing the machine electromagnetic torque Te [p.u.].
         """
 
-        return SimpleNamespace(Te=self.Te)
+        return SimpleNamespace(Te=self.Te, psi_PM=self.psi_PM)

--- a/soft4pes/model/machine/pmsm_param.py
+++ b/soft4pes/model/machine/pmsm_param.py
@@ -21,7 +21,7 @@ class PMSMParameters:
         Stator d-axis inductance [H].
     Lsq_SI : float
         Stator q-axis inductance [H].
-    LambdaPM_SI : float
+    Lambda_PM_SI : float
         Permanent magnet flux linkage [Wb].
     base : base value object
         Base values.
@@ -38,17 +38,18 @@ class PMSMParameters:
         Stator d-axis reactance [p.u.].
     Xsq : float
         Stator q-axis reactance [p.u.].
-    PsiPM : float
+    Psi_PM : float
         Permanent magnet flux linkage [p.u.].
     kT : float
         Torque factor [p.u.].
     """
 
-    def __init__(self, fs_SI, pf_SI, Rs_SI, Lsd_SI, Lsq_SI, LambdaPM_SI, base):
+    def __init__(self, fs_SI, pf_SI, Rs_SI, Lsd_SI, Lsq_SI, Lambda_PM_SI,
+                 base):
         self.ws = 2 * np.pi * fs_SI / base.w
         self.pf = pf_SI
         self.Rs = Rs_SI / base.Z
         self.Xsd = Lsd_SI / base.L
         self.Xsq = Lsq_SI / base.L
-        self.PsiPM = LambdaPM_SI * base.w / base.V
+        self.Psi_PM = Lambda_PM_SI * base.w / base.V
         self.kT = 1 / pf_SI

--- a/soft4pes/sim/simulation.py
+++ b/soft4pes/sim/simulation.py
@@ -217,7 +217,8 @@ class Simulation:
                         self.Ts_sim, self.disc_method)
 
                 # Update the system state
-                self.sys.update_state(self.matrices, u_abc, kTs_sim)
+                self.sys.update_state(self.matrices, u_abc, kTs_sim,
+                                      self.Ts_sim)
 
             progress_printer(k)
 

--- a/soft4pes/utils/plotter.py
+++ b/soft4pes/utils/plotter.py
@@ -554,7 +554,10 @@ class Plotter:
                 )
             elif isinstance(self.sys, PMSM):
                 # Use machine electrical angle for PMSM
-                theta = self.data.sys.theta_el
+                theta = np.arctan2(
+                    self.data.sys.x[:, 3],
+                    self.data.sys.x[:, 2],
+                )
             else:
                 theta = 2 * np.pi * 50 * self.data.sys.t - np.pi / 2
             return np.array(

--- a/soft4pes/utils/plotter.py
+++ b/soft4pes/utils/plotter.py
@@ -556,8 +556,8 @@ class Plotter:
             elif isinstance(self.sys, PMSM):
                 # Use machine electrical angle for PMSM
                 theta = np.arctan2(
-                    self.data.sys.x[:, 3],
-                    self.data.sys.x[:, 2],
+                    self.data.sys.psi_PM[:, 1],
+                    self.data.sys.psi_PM[:, 0],
                 )
             else:
                 theta = 2 * np.pi * 50 * self.data.sys.t - np.pi / 2


### PR DESCRIPTION
This PR changes the PMSM implementation from the dq-frame to alpha-beta frame. 

Parameters and model are from:
A. Benevieri, P. Karamanakos, A. Formentini and M. Marchesoni, "Gradient-Based Predictive Pulse Pattern Control for Permanent Magnet Synchronous Motor Drives," 2024 IEEE International Conference on Electrical Systems for Aircraft, Railway, Ship Propulsion and Road Vehicles & International Transportation Electrification Conference (ESARS-ITEC), Naples, Italy, 2024, pp. 1-6.

closes #123 