### PR TITLE
Add L-filter to parameter sets

### DIFF
--- a/docs/source/parameter_sets/drive/components/converters.rst
+++ b/docs/source/parameter_sets/drive/components/converters.rst
@@ -29,10 +29,10 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`750\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`2`
 
 
@@ -48,10 +48,10 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`750\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`3`
 
 
@@ -67,10 +67,10 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`5200\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`2`
 
 
@@ -86,8 +86,8 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`5200\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`3`

--- a/docs/source/parameter_sets/drive/components/machines.rst
+++ b/docs/source/parameter_sets/drive/components/machines.rst
@@ -41,48 +41,48 @@ Predefined Machine Models
      - Value [pu]
    * - Rated voltage
      - :math:`V_{m,R}`
-     - :math:`400\,\text{V}`
+     - :math:`400\,\textrm{V}`
      - 
    * - Rated current
      - :math:`I_{m,R}`
-     - :math:`4.4\,\text{A}`
+     - :math:`4.4\,\textrm{A}`
      - 
    * - Rated power
      - :math:`P_{m,R}`
-     - :math:`3\,\text{kW}`
+     - :math:`3\,\textrm{kW}`
      - 
    * - Rated frequency
      - :math:`f_{m,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Pole pairs
      - :math:`n_{pp}`
      - :math:`1`
      - 
    * - Power factor
-     - :math:`\mathrm{pf}`
+     - :math:`\textrm{pf}`
      - :math:`0.85`
      - 
    * - Stator resistance
      - :math:`R_s`
      - :math:`2.7\,\Omega`
-     - :math:`0.05\,\text{p.u.}`
+     - :math:`0.05\,\textrm{p.u.}`
    * - Rotor resistance
      - :math:`R_r`
      - :math:`2.4\,\Omega`
-     - :math:`0.05\,\text{p.u.}`
+     - :math:`0.05\,\textrm{p.u.}`
    * - Stator leakage inductance
      - :math:`L_{ls}`
-     - :math:`9.868\,\text{mH}`
-     - :math:`0.06\,\text{p.u.}`
+     - :math:`9.868\,\textrm{mH}`
+     - :math:`0.06\,\textrm{p.u.}`
    * - Rotor leakage inductance
      - :math:`L_{lr}`
-     - :math:`11.777\,\text{mH}`
-     - :math:`0.07\,\text{p.u.}`
+     - :math:`11.777\,\textrm{mH}`
+     - :math:`0.07\,\textrm{p.u.}`
    * - Mutual inductance
      - :math:`L_m`
-     - :math:`394.704\,\text{mH}`
-     - :math:`2.36\,\text{p.u.}`
+     - :math:`394.704\,\textrm{mH}`
+     - :math:`2.36\,\textrm{p.u.}`
 
 
 .. _mv-induction-machine:
@@ -99,48 +99,48 @@ Predefined Machine Models
      - Value [pu]
    * - Rated voltage
      - :math:`V_{m,R}`
-     - :math:`3300\,\text{V}`
+     - :math:`3300\,\textrm{V}`
      - 
    * - Rated current
      - :math:`I_{m,R}`
-     - :math:`356\,\text{A}`
+     - :math:`356\,\textrm{A}`
      - 
    * - Rated power
      - :math:`P_{m,R}`
-     - :math:`2\,\text{MW}`
+     - :math:`2\,\textrm{MW}`
      - 
    * - Rated frequency
      - :math:`f_{m,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Pole pairs
      - :math:`n_{pp}`
      - :math:`5`
      - 
    * - Power factor
-     - :math:`\mathrm{pf}`
+     - :math:`\textrm{pf}`
      - :math:`0.85`
      - 
    * - Stator resistance
      - :math:`R_s`
      - :math:`57.61\,\Omega`
-     - :math:`10.71\,\text{p.u.}`
+     - :math:`10.71\,\textrm{p.u.}`
    * - Rotor resistance
      - :math:`R_r`
      - :math:`48.89\,\Omega`
-     - :math:`9.14\,\text{p.u.}`
+     - :math:`9.14\,\textrm{p.u.}`
    * - Stator leakage inductance
      - :math:`L_{ls}`
-     - :math:`2.544\,\text{mH}`
-     - :math:`0.15\,\text{p.u.}`
+     - :math:`2.544\,\textrm{mH}`
+     - :math:`0.15\,\textrm{p.u.}`
    * - Rotor leakage inductance
      - :math:`L_{lr}`
-     - :math:`1.881\,\text{mH}`
-     - :math:`0.11\,\text{p.u.}`
+     - :math:`1.881\,\textrm{mH}`
+     - :math:`0.11\,\textrm{p.u.}`
    * - Mutual inductance
      - :math:`L_m`
-     - :math:`40.01\,\text{mH}`
-     - :math:`2.35\,\text{p.u.}`
+     - :math:`40.01\,\textrm{mH}`
+     - :math:`2.35\,\textrm{p.u.}`
 
 
 .. _lv-pmsm:
@@ -157,41 +157,41 @@ Predefined Machine Models
      - Value [pu]
    * - Rated voltage
      - :math:`V_{m,R}`
-     - :math:`274\,\text{V}`
+     - :math:`274\,\textrm{V}`
      - 
    * - Rated current
      - :math:`I_{m,R}`
-     - :math:`71\,\text{A}`
+     - :math:`71\,\textrm{A}`
      - 
    * - Rated power
      - :math:`P_{m,R}`
-     - :math:`33.7\,\text{kW}`
+     - :math:`33.7\,\textrm{kW}`
      - 
    * - Rated frequency
      - :math:`f_{m,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Pole pairs
      - :math:`n_{pp}`
      - :math:`4`
      - 
    * - Power factor
-     - :math:`\mathrm{pf}`
+     - :math:`\textrm{pf}`
      - :math:`1`
      - 
    * - Stator resistance
      - :math:`R_s`
      - :math:`0.3\,\Omega`
-     - :math:`0.13\,\text{p.u.}`
+     - :math:`0.13\,\textrm{p.u.}`
    * - Stator d-axis inductance
      - :math:`L_{sd}`
-     - :math:`4\,\text{mH}`
-     - :math:`0.56\,\text{p.u.}`
+     - :math:`4\,\textrm{mH}`
+     - :math:`0.56\,\textrm{p.u.}`
    * - Stator q-axis inductance
      - :math:`L_{sq}`
-     - :math:`5.5\,\text{mH}`
-     - :math:`0.78\,\text{p.u.}`
+     - :math:`5.5\,\textrm{mH}`
+     - :math:`0.78\,\textrm{p.u.}`
    * - Permanent magnet flux linkage
-     - :math:`\lambda_{\mathrm{PM}}`
-     - :math:`0.7\,\text{Wb}`
-     - :math:`0.98\,\text{p.u.}`
+     - :math:`\lambda_{\textrm{PM}}`
+     - :math:`0.7\,\textrm{Wb}`
+     - :math:`0.98\,\textrm{p.u.}`

--- a/docs/source/parameter_sets/drive/systems.rst
+++ b/docs/source/parameter_sets/drive/systems.rst
@@ -36,11 +36,11 @@ Predefined Drive Systems
      - Details
    * - Machine
      - :ref:`Low-voltage induction machine <lv-induction-machine>`
-     - :math:`V_{m,R} = 400\,\mathrm{V}`, :math:`I_{m,R} = 4.4\,\mathrm{A}`  
-       :math:`f_{m,R} = 50\,\mathrm{Hz}`
+     - :math:`V_{m,R} = 400\,\textrm{V}`, :math:`I_{m,R} = 4.4\,\textrm{A}`  
+       :math:`f_{m,R} = 50\,\textrm{Hz}`
    * - Converter
      - :ref:`2-Level low-voltage converter <2l-lv-converter>`
-     - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 750\,\textrm{V}`
 
 
 **3-level converter connected to a medium-voltage induction machine** (``MV_Induction_Machine_3L_Converter``)
@@ -54,11 +54,11 @@ Predefined Drive Systems
      - Details
    * - Machine
      - :ref:`Medium-voltage induction machine <mv-induction-machine>`
-     - :math:`V_{m,R} = 3300\,\mathrm{V}`, :math:`I_{m,R} = 356\,\mathrm{A}`  
-       :math:`f_{m,R} = 50\,\mathrm{Hz}`
+     - :math:`V_{m,R} = 3300\,\textrm{V}`, :math:`I_{m,R} = 356\,\textrm{A}`  
+       :math:`f_{m,R} = 50\,\textrm{Hz}`
    * - Converter
      - :ref:`3-Level medium-voltage converter <3l-mv-converter>`
-     - :math:`V_{\mathrm{dc}} = 5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 5200\,\textrm{V}`
 
 
 **2-level converter connected to a low-voltage PMSM** (``LV_PMSM_2L_Converter``)
@@ -72,11 +72,11 @@ Predefined Drive Systems
      - Details
    * - Machine
      - :ref:`Low-voltage PMSM <lv-pmsm>`
-     - :math:`V_{m,R} = 274\,\mathrm{V}`, :math:`I_{m,R} = 71\,\mathrm{A}`  
-       :math:`f_{m,R} = 50\,\mathrm{Hz}`
+     - :math:`V_{m,R} = 274\,\textrm{V}`, :math:`I_{m,R} = 71\,\textrm{A}`  
+       :math:`f_{m,R} = 50\,\textrm{Hz}`
    * - Converter
      - :ref:`2-Level low-voltage converter <2l-lv-converter>`
-     - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 750\,\textrm{V}`
 
 
 **3-level converter connected to a low-voltage PMSM** (``LV_PMSM_3L_Converter``)
@@ -90,8 +90,8 @@ Predefined Drive Systems
      - Details
    * - Machine
      - :ref:`Low-voltage PMSM <lv-pmsm>`
-     - :math:`V_{m,R} = 274\,\mathrm{V}`, :math:`I_{m,R} = 71\,\mathrm{A}`  
-       :math:`f_{m,R} = 50\,\mathrm{Hz}`
+     - :math:`V_{m,R} = 274\,\textrm{V}`, :math:`I_{m,R} = 71\,\textrm{A}`  
+       :math:`f_{m,R} = 50\,\textrm{Hz}`
    * - Converter
      - :ref:`3-Level low-voltage converter <3l-lv-converter>`
-     - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 750\,\textrm{V}`

--- a/docs/source/parameter_sets/grid/components.rst
+++ b/docs/source/parameter_sets/grid/components.rst
@@ -17,7 +17,7 @@ The following example shows how to create a grid system by combining individual 
                               filter_name='No_Filter',
                               converter_name='3L_LV_Converter')
 
-The config dictionary contains the entries ``base`` (grid base-value object), ``grid_params`` (grid-parameters object), ``lcl_params`` (filter-parameters object) and ``conv`` (converter object).
+The config dictionary contains the entries ``base`` (grid base-value object), ``grid_params`` (grid-parameters object), ``filter_params`` (filter-parameters object), and ``conv`` (converter object).
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/parameter_sets/grid/components/converters.rst
+++ b/docs/source/parameter_sets/grid/components/converters.rst
@@ -30,10 +30,10 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`750\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`2`
 
 
@@ -49,10 +49,10 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`750\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`3`
 
 .. _3l-mv-converter:
@@ -67,8 +67,8 @@ Predefined Converters
      - Symbol
      - Value
    * - Dc-link voltage
-     - :math:`V_{\mathrm{dc}}`
-     - :math:`5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}}`
+     - :math:`5200\,\textrm{V}`
    * - Converter voltage levels
-     - :math:`n_{\mathrm{conv}}`
+     - :math:`n_{\textrm{conv}}`
      - :math:`3`

--- a/docs/source/parameter_sets/grid/components/filters.rst
+++ b/docs/source/parameter_sets/grid/components/filters.rst
@@ -83,6 +83,41 @@ Predefined Filters
      - :math:`R_{\mathrm{fg}}`
      - :math:`0.5\,\mathrm{m}\Omega`
 
+.. _l-filter-lv:
+
+:math:`\mathrm{L}` **filter** (``LV_L_Filter``)
+
+.. list-table::
+   :widths: 30 30 40
+   :header-rows: 1
+
+   * - Parameter
+     - Symbol
+     - Value
+   * - Filter inductance
+     - :math:`L_{\mathrm{fc}}`
+     - :math:`3\,\text{mH}`
+   * - Filter resistance
+     - :math:`R_{\mathrm{fc}}`
+     - :math:`0.1\,\Omega`
+
+.. _l-filter-mv:
+
+:math:`\mathrm{L}` **filter** (``MV_L_Filter``)
+
+.. list-table::
+   :widths: 30 30 40
+   :header-rows: 1
+
+   * - Parameter
+     - Symbol
+     - Value
+   * - Filter inductance
+     - :math:`L_{\mathrm{fc}}`
+     - :math:`0.19\,\text{mH}`
+   * - Filter resistance
+     - :math:`R_{\mathrm{fc}}`
+     - :math:`0.5\,\text{m}\Omega`
 
 .. _no-filter:
 

--- a/docs/source/parameter_sets/grid/components/filters.rst
+++ b/docs/source/parameter_sets/grid/components/filters.rst
@@ -24,7 +24,7 @@ Predefined Filters
 
 .. _lcl-filter-1300:
 
-:math:`\mathrm{LCL}` **filter** (:math:`f_r = 1300\,\mathrm{Hz}`) (``LCL_Filter_fr_1300``)
+:math:`\textrm{LCL}` **filter** (:math:`f_r = 1300\,\textrm{Hz}`) (``LCL_Filter_fr_1300``)
 
 .. list-table::
    :widths: 30 30 40
@@ -34,28 +34,28 @@ Predefined Filters
      - Symbol
      - Value
    * - Filter converter-side inductance
-     - :math:`L_{\mathrm{fc}}`
-     - :math:`3\,\mathrm{mH}`
+     - :math:`L_{\textrm{fc}}`
+     - :math:`3\,\textrm{mH}`
    * - Filter converter-side resistance
-     - :math:`R_{\mathrm{fc}}`
+     - :math:`R_{\textrm{fc}}`
      - :math:`0.1\,\Omega`
    * - Filter capacitance
      - :math:`C`
-     - :math:`10\,\mu\mathrm{F}`
+     - :math:`10\,\mu\textrm{F}`
    * - Damping resistor (capacitor)
      - :math:`R_c`
-     - :math:`1\,\mathrm{m}\Omega`
+     - :math:`1\,\textrm{m}\Omega`
    * - Filter grid-side inductance
-     - :math:`L_{\mathrm{fg}}`
-     - :math:`3\,\mathrm{mH}`
+     - :math:`L_{\textrm{fg}}`
+     - :math:`3\,\textrm{mH}`
    * - Filter grid-side resistance
-     - :math:`R_{\mathrm{fg}}`
+     - :math:`R_{\textrm{fg}}`
      - :math:`0.1\,\Omega`
 
 
 .. _lcl-filter-380:
 
-:math:`\mathrm{LCL}` **filter** (:math:`f_r = 380\,\mathrm{Hz}`) (``LCL_Filter_fr_380``)
+:math:`\textrm{LCL}` **filter** (:math:`f_r = 380\,\textrm{Hz}`) (``LCL_Filter_fr_380``)
 
 .. list-table::
    :widths: 30 30 40
@@ -65,23 +65,23 @@ Predefined Filters
      - Symbol
      - Value
    * - Filter converter-side inductance
-     - :math:`L_{\mathrm{fc}}`
-     - :math:`0.4\,\mathrm{mH}`
+     - :math:`L_{\textrm{fc}}`
+     - :math:`0.4\,\textrm{mH}`
    * - Filter converter-side resistance
-     - :math:`R_{\mathrm{fc}}`
-     - :math:`0.5\,\mathrm{m}\Omega`
+     - :math:`R_{\textrm{fc}}`
+     - :math:`0.5\,\textrm{m}\Omega`
    * - Filter capacitance
      - :math:`C`
-     - :math:`850\,\mu\mathrm{F}`
+     - :math:`850\,\mu\textrm{F}`
    * - Damping resistor (capacitor)
      - :math:`R_c`
-     - :math:`0.4\,\mathrm{m}\Omega`
+     - :math:`0.4\,\textrm{m}\Omega`
    * - Filter grid-side inductance
-     - :math:`L_{\mathrm{fg}}`
-     - :math:`0.4\,\mathrm{mH}`
+     - :math:`L_{\textrm{fg}}`
+     - :math:`0.4\,\textrm{mH}`
    * - Filter grid-side resistance
-     - :math:`R_{\mathrm{fg}}`
-     - :math:`0.5\,\mathrm{m}\Omega`
+     - :math:`R_{\textrm{fg}}`
+     - :math:`0.5\,\textrm{m}\Omega`
 
 .. _l-filter-lv:
 

--- a/docs/source/parameter_sets/grid/components/grids.rst
+++ b/docs/source/parameter_sets/grid/components/grids.rst
@@ -35,24 +35,24 @@ Predefined Grids
      - Value [pu]
    * - Grid rated voltage (line-to-line, rms)
      - :math:`V_{g,R}`
-     - :math:`400\,\text{V}`
+     - :math:`400\,\textrm{V}`
      - 
    * - Grid rated current (rms)
      - :math:`I_{g,R}`
-     - :math:`18\,\text{A}`
+     - :math:`18\,\textrm{A}`
      - 
    * - Grid rated frequency
      - :math:`f_{g,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Grid resistance
      - :math:`R_g`
      - :math:`0.07\,\Omega`
-     - :math:`0.006\,\text{p.u.}`
+     - :math:`0.006\,\textrm{p.u.}`
    * - Grid inductance
      - :math:`L_g`
-     - :math:`30\,\text{mH}`
-     - :math:`0.73\,\text{p.u.}`
+     - :math:`30\,\textrm{mH}`
+     - :math:`0.73\,\textrm{p.u.}`
 
 .. _strong-lv-grid:
 
@@ -68,24 +68,24 @@ Predefined Grids
      - Value [pu]
    * - Grid rated voltage (line-to-line, rms)
      - :math:`V_{g,R}`
-     - :math:`400\,\text{V}`
+     - :math:`400\,\textrm{V}`
      - 
    * - Grid rated current (rms)
      - :math:`I_{g,R}`
-     - :math:`18\,\text{A}`
+     - :math:`18\,\textrm{A}`
      - 
    * - Grid rated frequency
      - :math:`f_{g,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Grid resistance
      - :math:`R_g`
      - :math:`0.07\,\Omega`
-     - :math:`0.006\,\text{p.u.}`
+     - :math:`0.006\,\textrm{p.u.}`
    * - Grid inductance
      - :math:`L_g`
-     - :math:`5\,\text{mH}`
-     - :math:`0.12\,\text{p.u.}`
+     - :math:`5\,\textrm{mH}`
+     - :math:`0.12\,\textrm{p.u.}`
 
 .. _strong-mv-grid:
 
@@ -101,21 +101,21 @@ Predefined Grids
      - Value [pu]
    * - Grid rated voltage (line-to-line, rms)
      - :math:`V_{g,R}`
-     - :math:`3300\,\text{V}`
+     - :math:`3300\,\textrm{V}`
      - 
    * - Grid rated current (rms)
      - :math:`I_{g,R}`
-     - :math:`1575\,\text{A}`
+     - :math:`1575\,\textrm{A}`
      - 
    * - Grid rated frequency
      - :math:`f_{g,R}`
-     - :math:`50\,\text{Hz}`
+     - :math:`50\,\textrm{Hz}`
      - 
    * - Grid resistance
      - :math:`R_g`
      - :math:`0.006\,\Omega`
-     - :math:`0.0004\,\text{p.u.}`
+     - :math:`0.0004\,\textrm{p.u.}`
    * - Grid inductance
      - :math:`L_g`
-     - :math:`0.19\,\text{mH}`
-     - :math:`0.005\,\text{p.u.}`
+     - :math:`0.19\,\textrm{mH}`
+     - :math:`0.005\,\textrm{p.u.}`

--- a/docs/source/parameter_sets/grid/systems.rst
+++ b/docs/source/parameter_sets/grid/systems.rst
@@ -64,7 +64,7 @@ Predefined Grid Systems
      - Details
    * - Grid
      - :ref:`Strong low-voltage grid <strong-lv-grid>`
-     - :math:`V_R = 400\,\mathrm{V}`, :math:`I_R = 25\,\mathrm{A}`
+     - :math:`V_R = 400\,\mathrm{V}`, :math:`I_R = 18\,\mathrm{A}`
    * - Filter
      - :ref:`LCL filter <lcl-filter-1300>`
      - :math:`f_R = 1300\,\mathrm{Hz}`
@@ -72,8 +72,7 @@ Predefined Grid Systems
      - :ref:`2-Level converter <2l-lv-converter>`
      - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
 
-
-**3-level converter connected to a strong medium-voltage grid without a filter**
+**3-level converter connected to a strong medium-voltage grid via an** :math:`\mathrm{L}` **filter**
 
 .. list-table::
    :widths: 30 30 40
@@ -86,8 +85,8 @@ Predefined Grid Systems
      - :ref:`Strong medium-voltage grid <strong-mv-grid>`
      - :math:`V_R = 3300\,\mathrm{V}`, :math:`I_R = 1575\,\mathrm{A}`
    * - Filter
-     - :ref:`No filter <no-filter>`
-     - no filter
+     - :ref:`L filter <l-filter-mv>`
+     - :math:`L_{\mathrm{fc}} = 0.19\,\mathrm{mH}`, :math:`R_{\mathrm{fc}} = 0.5\,\mathrm{m}\Omega`
    * - Converter
      - :ref:`3-Level converter <3l-mv-converter>`
      - :math:`V_{\mathrm{dc}} = 5200\,\mathrm{V}`

--- a/docs/source/parameter_sets/grid/systems.rst
+++ b/docs/source/parameter_sets/grid/systems.rst
@@ -33,7 +33,7 @@ The components are defined in the same file, and predefined components can be fo
 Predefined Grid Systems
 -----------------------
 
-**2-level converter connected to a weak low-voltage grid via an** :math:`\mathrm{LCL}` **filter**
+**2-level converter connected to a weak low-voltage grid via an** :math:`\textrm{LCL}` **filter**
 
 .. list-table::
    :widths: 30 30 40
@@ -44,16 +44,16 @@ Predefined Grid Systems
      - Details
    * - Grid
      - :ref:`Weak low-voltage grid <weak-lv-grid>`
-     - :math:`V_R = 400\,\mathrm{V}`, :math:`I_R = 18\,\mathrm{A}`
+     - :math:`V_R = 400\,\textrm{V}`, :math:`I_R = 18\,\textrm{A}`
    * - Filter
      - :ref:`LCL filter <lcl-filter-1300>`
-     - :math:`f_R = 1300\,\mathrm{Hz}`
+     - :math:`f_R = 1300\,\textrm{Hz}`
    * - Converter
      - :ref:`2-Level converter <2l-lv-converter>`
-     - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 750\,\textrm{V}`
 
 
-**2-level converter connected to a strong low-voltage grid via an** :math:`\mathrm{LCL}` **filter**
+**2-level converter connected to a strong low-voltage grid via an** :math:`\textrm{LCL}` **filter**
 
 .. list-table::
    :widths: 30 30 40
@@ -64,13 +64,13 @@ Predefined Grid Systems
      - Details
    * - Grid
      - :ref:`Strong low-voltage grid <strong-lv-grid>`
-     - :math:`V_R = 400\,\mathrm{V}`, :math:`I_R = 18\,\mathrm{A}`
+     - :math:`V_R = 400\,\textrm{V}`, :math:`I_R = 18\,\textrm{A}`
    * - Filter
      - :ref:`LCL filter <lcl-filter-1300>`
-     - :math:`f_R = 1300\,\mathrm{Hz}`
+     - :math:`f_R = 1300\,\textrm{Hz}`
    * - Converter
      - :ref:`2-Level converter <2l-lv-converter>`
-     - :math:`V_{\mathrm{dc}} = 750\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 750\,\textrm{V}`
 
 **3-level converter connected to a strong medium-voltage grid via an** :math:`\mathrm{L}` **filter**
 
@@ -83,16 +83,16 @@ Predefined Grid Systems
      - Details
    * - Grid
      - :ref:`Strong medium-voltage grid <strong-mv-grid>`
-     - :math:`V_R = 3300\,\mathrm{V}`, :math:`I_R = 1575\,\mathrm{A}`
+     - :math:`V_R = 3300\,\textrm{V}`, :math:`I_R = 1575\,\textrm{A}`
    * - Filter
      - :ref:`L filter <l-filter-mv>`
      - :math:`L_{\mathrm{fc}} = 0.19\,\mathrm{mH}`, :math:`R_{\mathrm{fc}} = 0.5\,\mathrm{m}\Omega`
    * - Converter
      - :ref:`3-Level converter <3l-mv-converter>`
-     - :math:`V_{\mathrm{dc}} = 5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 5200\,\textrm{V}`
 
 
-**3-level converter connected to a strong medium-voltage grid via an** :math:`\mathrm{LCL}` **filter**
+**3-level converter connected to a strong medium-voltage grid via an** :math:`\textrm{LCL}` **filter**
 
 .. list-table::
    :widths: 30 30 40
@@ -103,10 +103,10 @@ Predefined Grid Systems
      - Details
    * - Grid
      - :ref:`Strong medium-voltage grid <strong-mv-grid>`
-     - :math:`V_R = 3300\,\mathrm{V}`, :math:`I_R = 1575\,\mathrm{A}`
+     - :math:`V_R = 3300\,\textrm{V}`, :math:`I_R = 1575\,\textrm{A}`
    * - Filter
      - :ref:`LCL filter <lcl-filter-380>`
-     - :math:`f_R = 380\,\mathrm{Hz}`
+     - :math:`f_R = 380\,\textrm{Hz}`
    * - Converter
      - :ref:`3-Level converter <3l-mv-converter>`
-     - :math:`V_{\mathrm{dc}} = 5200\,\mathrm{V}`
+     - :math:`V_{\textrm{dc}} = 5200\,\textrm{V}`

--- a/examples/grid/grid_forming_ctr.py
+++ b/examples/grid/grid_forming_ctr.py
@@ -21,7 +21,7 @@ from soft4pes.utils.plotter import Plotter
 # is used.
 config = get_default_system(name='Weak_LV_Grid_LCL_Filter_2L_conv')
 sys = model.grid.RLGridLCLFilter(par_grid=config.grid_params,
-                                 par_lcl_filter=config.lcl_params,
+                                 par_lcl_filter=config.filter_params,
                                  conv=config.conv,
                                  base=config.base)
 

--- a/examples/grid/pars/grid_config.py
+++ b/examples/grid/pars/grid_config.py
@@ -87,7 +87,7 @@ def create_grid_parameters(grid_params, base):
 
 def create_system(grid_params, filter_params, conv, base):
     """
-    Create the system model based on the presence of a filter.
+    Create the system model based on the presence and type of a filter.
 
     Parameters
     ----------
@@ -105,13 +105,30 @@ def create_system(grid_params, filter_params, conv, base):
     tuple
         System object and optional filter parameters.
     """
-    if filter_params:  # If a filter is defined
-        lcl_params = model.grid.LCLFilterParameters(**filter_params, base=base)
+    # No filter
+    if not filter_params:
+        sys = model.grid.RLGrid(grid_params, conv, base)
+        return sys, None
+
+    # With filter: dispatch by type
+    f_type = filter_params.get("Type", "").upper()
+
+    if f_type == "LCL":
+        lcl_params = model.grid.LCLFilterParameters(
+            **{k: v for k, v in filter_params.items() if k != "Type"},
+                                                    base=base)
         sys = model.grid.RLGridLCLFilter(grid_params, lcl_params, conv, base)
         return sys, lcl_params
-    
-    sys = model.grid.RLGrid(grid_params, conv, base)
-    return sys, None
+
+    if f_type == "L":
+        l_params = model.grid.LFilterParameters(
+            **{k: v for k, v in filter_params.items() if k != "Type"},
+                                                base=base)
+        sys = model.grid.RLGridLFilter(grid_params, l_params, conv, base)
+        return sys, l_params
+
+    # Unknown/unsupported type
+    raise ValueError(f"Unsupported filter type '{f_type}'")
 
 
 def get_custom_system(grid_name, filter_name, converter_name):
@@ -160,7 +177,7 @@ def get_custom_system(grid_name, filter_name, converter_name):
     grid_params_obj = create_grid_parameters(grid_params, base)
 
     # Create the system
-    sys, lcl_params = create_system(grid_params_obj, filter_params, conv, base)
+    sys, filter_params_obj = create_system(grid_params_obj, filter_params, conv, base)
 
     # Return the system components
     return SimpleNamespace(
@@ -168,7 +185,7 @@ def get_custom_system(grid_name, filter_name, converter_name):
         base=base,
         grid_params=grid_params_obj,
         conv=conv,
-        lcl_params=lcl_params,
+        filter_params=filter_params_obj,
         sys=sys)
 
 

--- a/examples/grid/pars/grid_parameter_sets.json
+++ b/examples/grid/pars/grid_parameter_sets.json
@@ -9,9 +9,9 @@
         },
         "Strong_LV_Grid": {
             "Vg_R_SI": 400,
-            "Ig_R_SI": 25,
+            "Ig_R_SI": 18,
             "fg_R_SI": 50,
-            "Rg_SI": 0.02,
+            "Rg_SI": 0.07,
             "Lg_SI": 5e-3
         },
         "Strong_MV_Grid": {
@@ -24,6 +24,7 @@
     },
     "filters": {
         "LCL_Filter_fr_1300": {
+            "Type": "LCL",
             "L_fc_SI": 3e-3,
             "R_fc_SI": 0.1,
             "C_SI": 10e-6,
@@ -32,12 +33,23 @@
             "R_fg_SI": 0.1
         },
         "LCL_Filter_fr_380": {
+            "Type": "LCL",
             "L_fc_SI": 0.4e-3,
             "R_fc_SI": 0.5e-3,
             "C_SI": 850e-6,
             "R_c_SI": 0.4e-3,
             "L_fg_SI": 0.4e-3,
             "R_fg_SI": 0.5e-3
+        },
+        "LV_L_Filter": {
+            "Type": "L",
+            "L_fc_SI": 3e-3,
+            "R_fc_SI": 0.1
+        },
+        "MV_L_Filter": {
+            "Type": "L",
+            "L_fc_SI": 0.19e-3,
+            "R_fc_SI": 0.5e-3
         },
         "No_Filter": null
     },
@@ -72,12 +84,12 @@
             "filter": "LCL_Filter_fr_1300",
             "converter": "2L_LV_Converter"
         },
-        "Strong_MV_Grid_No_Filter_3L_conv": {
+        "Strong_MV_Grid_L_Filter_3L_conv": {
             "description": [
-                "3-level converter connected to a strong medium-voltage grid without a filter"
+                "3-level converter connected to a strong medium-voltage grid via an L filter"
             ],
             "grid": "Strong_MV_Grid",
-            "filter": "No_Filter",
+            "filter": "MV_L_Filter",
             "converter": "3L_MV_Converter"
         },
         "Strong_MV_Grid_LCL_3L_conv": {

--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -19,7 +19,7 @@ from soft4pes.utils.plotter import Plotter
 # documentation. Here, a 3-level converter connected to a strong, low voltage grid without a filter
 # is used.
 config = get_custom_system(grid_name='Strong_LV_Grid',
-                           filter_name='MV_L_Filter',
+                           filter_name='LV_L_Filter',
                            converter_name='3L_LV_Converter')
 
 # Create the system model consisting of the grid and converter

--- a/examples/grid/rl_grid_direct_mpc_curr_ctr.py
+++ b/examples/grid/rl_grid_direct_mpc_curr_ctr.py
@@ -19,13 +19,14 @@ from soft4pes.utils.plotter import Plotter
 # documentation. Here, a 3-level converter connected to a strong, low voltage grid without a filter
 # is used.
 config = get_custom_system(grid_name='Strong_LV_Grid',
-                           filter_name='No_Filter',
+                           filter_name='MV_L_Filter',
                            converter_name='3L_LV_Converter')
 
 # Create the system model consisting of the grid and converter
-sys = model.grid.RLGrid(par=config.grid_params,
-                        conv=config.conv,
-                        base=config.base)
+sys = model.grid.RLGridLFilter(par_grid=config.grid_params,
+                               par_l_filter=config.filter_params,
+                               conv=config.conv,
+                               base=config.base)
 
 # Define power reference sequences
 # The first array contains the time instants (in seconds) and the second array the corresponding


### PR DESCRIPTION
This PR adds possibility to use an L-filter with the predefined parameter sets. User can now choose between L-filter, LCL-filter and filterless operation with a grid-connected converter

closes #127 