### PR TITLE
Add common mode signal injection to modulation

### DIFF
--- a/examples/grid/grid_forming_ctr.py
+++ b/examples/grid/grid_forming_ctr.py
@@ -59,11 +59,14 @@ control_loops = [rfpsc, vc_mpc]  # Use MPC with RFPSC
 # vc_ctr = lin.LCLVcCtr(sys=config.sys, I_conv_max=1.3, curr_ctr=ic_ctr)
 # control_loops = [rfpsc, vc_ctr, ic_ctr]
 
-# Define the control system. Set pwm to None to disable PWM.
-ctr_sys = common.ControlSystem(control_loops=control_loops,
-                               ref_seq=ref_seq,
-                               Ts=100e-6,
-                               pwm=modulation.CarrierPWM())
+# Define the control system. Set pwm to None to disable PWM and common_mode_inj to None to disable
+# common-mode injection.
+ctr_sys = common.ControlSystem(
+    control_loops=control_loops,
+    ref_seq=ref_seq,
+    Ts=100e-6,
+    pwm=modulation.CarrierPWM(),
+    common_mode_inj=modulation.CommonModeInjection(mode='MinMax'))
 
 # Simulate the system. In order to get accurate results with PWM, the simulation time step should
 # be at least two magnitudes lower than the control time step.

--- a/soft4pes/control/common/control_system.py
+++ b/soft4pes/control/common/control_system.py
@@ -23,6 +23,8 @@ class ControlSystem:
         Sampling interval [s].
     pwm : modulator, optional
         Modulator for generating three-phase switch positions.
+    common_mode_inj : CommonModeInjection, optional
+        Common-mode injection for the modulating signal.
 
     Attributes
     ----------
@@ -38,10 +40,20 @@ class ControlSystem:
         List of controller instances.
     """
 
-    def __init__(self, control_loops, ref_seq, Ts, pwm=None):
+    def __init__(self,
+                 control_loops,
+                 ref_seq,
+                 Ts,
+                 pwm=None,
+                 common_mode_inj=None):
         self.ref_seq = ref_seq
         self.data = SimpleNamespace(t=[], u_abc_ref=[])
         self.Ts = Ts
+
+        # If common-mode injection is provided, it is added to the control loops list before the
+        # modulator. The injection can also be used when using just modulating signal feedforward.
+        if common_mode_inj is not None:
+            control_loops = control_loops + [common_mode_inj]
 
         # If PWM is provided, it is added to the control loops list to be the last loop of the
         # control system.

--- a/soft4pes/control/modulation/__init__.py
+++ b/soft4pes/control/modulation/__init__.py
@@ -4,7 +4,9 @@ Modulation methods for power electronic converters.
 """
 
 from soft4pes.control.modulation.carrier_pwm import CarrierPWM
+from soft4pes.control.modulation.common_mode_injection import CommonModeInjection
 
 __all__ = [
     "CarrierPWM",
+    "CommonModeInjection",
 ]

--- a/soft4pes/control/modulation/carrier_pwm.py
+++ b/soft4pes/control/modulation/carrier_pwm.py
@@ -2,12 +2,28 @@
 Asynchronous carrier-based pulse width modulation (CB-PWM) for two and three-level converters.  
 """
 
+from types import SimpleNamespace
 import numpy as np
 from soft4pes.control.common.controller import Controller
-from types import SimpleNamespace
 
 
 class CarrierPWM(Controller):
+    """
+    Asynchronous carrier-based pulse width modulation (CB-PWM) for two and three-level converters.
+    The modulating signal is sampled at the peaks of the carrier, resulting in the device switching 
+    frequency of 1/(2Ts) for two-level converters. For three-level converters, the device switching 
+    frequency is roughly half the apparent switching, ie. the carrier frequency, when 
+    phase-disposition PWM is used.
+
+    Parameters
+    ----------
+    None
+
+    Attributes
+    ----------
+    carrier_rising : bool
+        Flag indicating whether the carrier is rising or falling. 
+    """
 
     def __init__(self):
         super().__init__()
@@ -16,10 +32,7 @@ class CarrierPWM(Controller):
     def execute(self, sys, kTs):
         """
         Generate switching time instants and switch positions using asynchronous carrier-based pulse 
-        width modulation (CB-PWM). The modulating signal is sampled at the peaks of the carrier, 
-        resulting in the device switching frequency of 1/(2Ts) for two-level converters. For three-
-        level converters, the device switching frequency is roughly half the apparent switching, ie.
-        the carrier frequency, when phase-disposition PWM is used.
+        width modulation (CB-PWM). 
 
         The produced output is presented below. Note that the switching times are in ascending 
         order.

--- a/soft4pes/control/modulation/common_mode_injection.py
+++ b/soft4pes/control/modulation/common_mode_injection.py
@@ -1,0 +1,68 @@
+"""
+Common-mode injection for modulating signal.
+"""
+
+from types import SimpleNamespace
+import numpy as np
+from soft4pes.control.common.controller import Controller
+
+
+class CommonModeInjection(Controller):
+    """
+    Common-mode injection for modulating signal. The selected common-mode injection method
+    computes a common-mode voltage component that is added to the three-phase modulating signal.
+    Common-mode injection is applicable for carrier-based PWM schemes and for modulating-signal
+    feedforward.
+
+    Available common-mode injection methods:
+    - MinMax: Adds a common-mode component u_cm = -0.5 * (max(u_ref_abc) + min(u_ref_abc)) to the 
+      modulating signal. For a two level converter, this method is equivalent to space-vector 
+      modulation (SVM). 
+
+    Parameters
+    ----------
+    mode : str, optional
+        Common-mode injection method. Default is 'MinMax', which is the only available method.
+
+    Attributes
+    ----------
+    mode : str
+        Common-mode injection method.
+    """
+
+    def __init__(self, mode='MinMax'):
+        super().__init__()
+        self.mode = mode
+
+    def execute(self, sys, kTs):
+        """
+        Apply common-mode injection.
+
+        Parameters
+        ----------
+        sys : system object
+            The system model (not used).
+        kTs : float
+            Current discrete time instant [s] (not used).
+
+        Returns
+        -------
+        u_ref_abc_cm : 3 x 1 ndarray
+            Three-phase modulating signal with common-mode injection.
+        """
+
+        u_ref_abc = self.input.u_abc
+
+        if self.mode == 'MinMax':
+            u_max = np.max(u_ref_abc)
+            u_min = np.min(u_ref_abc)
+            u_cm = -0.5 * (u_max + u_min)
+        else:
+            raise ValueError(
+                f'Common mode injection mode {self.mode} not recognized. Available '
+                'modes: MinMax.')
+
+        u_ref_abc_cm = u_ref_abc + u_cm
+        self.output = SimpleNamespace(u_abc=u_ref_abc_cm)
+
+        return self.output


### PR DESCRIPTION
This PR adds a module that can be used to to add a common-mode component to the modulating signal. The module can be used to develop more injection methods. Now it only contains Min-max injection method

closes #130 